### PR TITLE
bugfix/APPS-1522 — prevent "Enrollment Invalid DateTime" from appearing in dropdown

### DIFF
--- a/src/containers/participant/utils/ParticipantProfileUtils.js
+++ b/src/containers/participant/utils/ParticipantProfileUtils.js
@@ -4,7 +4,6 @@ import { DateTime } from 'luxon';
 
 import { getEntityProperties } from '../../../utils/DataUtils';
 import { PROPERTY_TYPE_FQNS } from '../../../core/edm/constants/FullyQualifiedNames';
-import { EMPTY_FIELD } from '../../participants/ParticipantsConstants';
 
 const { DATETIME_RECEIVED, CHECK_IN_DATETIME, ORIENTATION_DATETIME } = PROPERTY_TYPE_FQNS;
 
@@ -17,17 +16,17 @@ const generateDiversionPlanOptions = (entities :List) :Object[] => {
       [ORIENTATION_DATETIME]: orientationDateTime,
     } = getEntityProperties(entity, [DATETIME_RECEIVED, CHECK_IN_DATETIME, ORIENTATION_DATETIME]);
 
-    let label :string = 'Enrollment ';
+    let date :string = '';
     const sentenceDateObj = DateTime.fromISO(sentenceDateTime);
     const checkInDateObj = DateTime.fromISO(checkInDateTime);
     const orientationDateObj = DateTime.fromISO(orientationDateTime);
 
-    if (sentenceDateObj.isValid) label += sentenceDateObj.toLocaleString(DateTime.DATE_SHORT);
-    else if (checkInDateObj.isValid) label += checkInDateObj.toLocaleString(DateTime.DATE_SHORT);
-    else if (orientationDateObj.isValid) label += orientationDateObj.toLocaleString(DateTime.DATE_SHORT);
-    else label = EMPTY_FIELD;
+    if (sentenceDateObj.isValid) date = sentenceDateObj.toLocaleString(DateTime.DATE_SHORT);
+    else if (checkInDateObj.isValid) date = checkInDateObj.toLocaleString(DateTime.DATE_SHORT);
+    else if (orientationDateObj.isValid) date = orientationDateObj.toLocaleString(DateTime.DATE_SHORT);
+    else date = '– Date Unknown';
 
-    options.push({ label, value: entity });
+    options.push({ label: `Enrollment ${date}`, value: entity });
   });
   return options;
 };


### PR DESCRIPTION
display '----' if there are no dates associated with a CWP enrollment rather than displaying InvalidDateTime.

<img width="321" alt="Screen Shot 2019-11-21 at 10 13 31 AM" src="https://user-images.githubusercontent.com/32921059/69364681-99c11280-0c47-11ea-8c4b-5ef998206993.png">
