### PR TITLE
bugfix/APPS-1531 — judge and charges forms should enable immediately after submitting case

### DIFF
--- a/src/containers/participant/cases/AssignJudgeForm.js
+++ b/src/containers/participant/cases/AssignJudgeForm.js
@@ -60,8 +60,10 @@ class AssignJudgeForm extends Component<Props, State> {
   }
 
   componentDidUpdate(prevProps :Props) {
-    const { judge, judges } = this.props;
-    if (!prevProps.judge.equals(judge) || !prevProps.judges.equals(judges)) {
+    const { judge, judges, personCase } = this.props;
+    if (!prevProps.judge.equals(judge)
+      || !prevProps.judges.equals(judges)
+      || !prevProps.personCase.equals(personCase)) {
       this.prepopulateFormData();
     }
   }

--- a/src/containers/participant/cases/EditChargesForm.js
+++ b/src/containers/participant/cases/EditChargesForm.js
@@ -99,9 +99,10 @@ class EditChargesForm extends Component<Props, State> {
   }
 
   componentDidUpdate(prevProps :Props) {
-    const { charges, chargesForCase } = this.props;
+    const { charges, chargesForCase, personCase } = this.props;
     if (!prevProps.chargesForCase.equals(chargesForCase)
-      || !prevProps.charges.equals(charges)) {
+      || !prevProps.charges.equals(charges)
+      || !prevProps.personCase.equals(personCase)) {
       this.prepopulateFormData();
     }
   }


### PR DESCRIPTION
Now this screen goes from this (Assign Judge and Edit Case are both disabled):
<img width="1011" alt="Screen Shot 2019-11-25 at 4 22 30 PM" src="https://user-images.githubusercontent.com/32921059/69589173-0cabef80-0fa0-11ea-8921-e113820f646d.png">

to this (now enabled):
<img width="1030" alt="Screen Shot 2019-11-25 at 4 22 03 PM" src="https://user-images.githubusercontent.com/32921059/69589177-10d80d00-0fa0-11ea-9c8a-13802c5c204c.png">

...immediately after case first-time submission happens.