### PR TITLE
bugfix/APPS-1576 — add notSetValue as default for nonexistent contact methods

### DIFF
--- a/src/containers/participant/ParticipantReducer.js
+++ b/src/containers/participant/ParticipantReducer.js
@@ -846,8 +846,8 @@ export default function participantReducer(state :Map<*, *> = INITIAL_STATE, act
           const contactInfo :Map = value;
 
           return state
-            .set(EMAIL, contactInfo.get(CONTACT_METHODS.EMAIL))
-            .set(PHONE, contactInfo.get(CONTACT_METHODS.PHONE))
+            .set(EMAIL, contactInfo.get(CONTACT_METHODS.EMAIL, Map()))
+            .set(PHONE, contactInfo.get(CONTACT_METHODS.PHONE, Map()))
             .setIn([ACTIONS, GET_CONTACT_INFO, REQUEST_STATE], RequestStates.SUCCESS);
         },
         FAILURE: () => state


### PR DESCRIPTION
accidentally forgot to add empty `Map()` as default value for contact info entities, which was causing state values to be `undefined`.