### PR TITLE
bugfix/APPS-1589 — fix text in Print Infraction screen

### DIFF
--- a/src/containers/participant/print/PrintInfractionContainer.js
+++ b/src/containers/participant/print/PrintInfractionContainer.js
@@ -10,6 +10,7 @@ import {
   MinusButton,
   PlusButton,
   Select,
+  Sizes,
 } from 'lattice-ui-kit';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -30,7 +31,6 @@ import {
   PERSON_INFRACTIONS,
   STATE
 } from '../../../utils/constants/ReduxStateConsts';
-import { APP_CONTENT_WIDTH } from '../../../core/style/Sizes';
 
 const { PEOPLE } = APP_TYPE_FQNS;
 const {
@@ -55,6 +55,7 @@ const {
   INFRACTION_EVENT,
   INFRACTION_TYPE,
 } = PERSON_INFRACTIONS;
+const { APP_CONTENT_WIDTH } = Sizes;
 
 // $FlowFixMe
 const PenningtonSherrifsHeader = styled.img.attrs({


### PR DESCRIPTION
Text containers in Print Infraction screen wrap text and break on word now:

<img width="1128" alt="Screen Shot 2019-12-02 at 3 55 39 PM" src="https://user-images.githubusercontent.com/32921059/70004769-59517680-151c-11ea-9b5e-af3eb5f20949.png">
