### PR TITLE
2019-12-20 release

### DIFF
--- a/src/containers/participant/EditEnrollmentDatesForm.js
+++ b/src/containers/participant/EditEnrollmentDatesForm.js
@@ -24,12 +24,7 @@ import {
   schema,
   uiSchema,
 } from './schemas/EditEnrollmentDatesSchemas';
-import {
-  getEntityKeyId,
-  getEntityProperties,
-  getEntitySetIdFromApp,
-  getPropertyTypeIdFromEdm
-} from '../../utils/DataUtils';
+import { getEntityKeyId, getEntityProperties } from '../../utils/DataUtils';
 import { BackNavButton } from '../../components/controls/index';
 import { PARTICIPANT_PROFILE_WIDTH } from '../../core/style/Sizes';
 import {
@@ -47,7 +42,6 @@ const {
   CHECK_IN_DATETIME,
   DATETIME_END,
   DATETIME_RECEIVED,
-  DATETIME_START,
   ORIENTATION_DATETIME,
 } = PROPERTY_TYPE_FQNS;
 
@@ -78,9 +72,7 @@ type Props = {
     getEnrollmentStatus :RequestSequence;
     goToRoute :GoToRoute;
   },
-  app :Map;
   diversionPlan :Map;
-  edm :Map;
   entitySetIds :Map;
   getEnrollmentStatusRequestState :RequestState;
   initializeAppRequestState :RequestState;
@@ -190,24 +182,6 @@ class EditCaseInfoForm extends Component<Props, State> {
     return entityIndexToIdMap;
   }
 
-  createEntitySetIdsMap = () => {
-    const { app } = this.props;
-    return {
-      [DIVERSION_PLAN]: getEntitySetIdFromApp(app, DIVERSION_PLAN)
-    };
-  }
-
-  createPropertyTypeIdsMap = () => {
-    const { edm } = this.props;
-    return {
-      [CHECK_IN_DATETIME]: getPropertyTypeIdFromEdm(edm, CHECK_IN_DATETIME),
-      [DATETIME_END]: getPropertyTypeIdFromEdm(edm, DATETIME_END),
-      [DATETIME_RECEIVED]: getPropertyTypeIdFromEdm(edm, DATETIME_RECEIVED),
-      [DATETIME_START]: getPropertyTypeIdFromEdm(edm, DATETIME_START),
-      [ORIENTATION_DATETIME]: getPropertyTypeIdFromEdm(edm, ORIENTATION_DATETIME),
-    };
-  }
-
   handleOnClickBackButton = () => {
     const {
       actions,
@@ -240,8 +214,6 @@ class EditCaseInfoForm extends Component<Props, State> {
     }
 
     const entityIndexToIdMap = this.createEntityIndexToIdMap();
-    // const entitySetIds = this.createEntitySetIdsMap();
-    // const propertyTypeIds = this.createPropertyTypeIdsMap();
 
     const formContext = {
       editAction: actions.editEnrollmentDates,
@@ -280,9 +252,7 @@ const mapStateToProps = (state :Map) => {
   const person = state.get(STATE.PERSON);
   const selectedOrgId :string = app.get(SELECTED_ORG_ID);
   return ({
-    app,
     [PERSON.DIVERSION_PLAN]: person.get(PERSON.DIVERSION_PLAN),
-    edm: state.get(STATE.EDM),
     entitySetIds: app.getIn([ENTITY_SET_IDS_BY_ORG, selectedOrgId], Map()),
     getEnrollmentStatusRequestState: person.getIn([ACTIONS, GET_ENROLLMENT_STATUS, REQUEST_STATE]),
     initializeAppRequestState: app.getIn([APP.ACTIONS, APP.INITIALIZE_APPLICATION, APP.REQUEST_STATE]),

--- a/src/containers/participant/assignedworksites/EditWorksitePlanForm.js
+++ b/src/containers/participant/assignedworksites/EditWorksitePlanForm.js
@@ -15,15 +15,10 @@ import type { RequestSequence } from 'redux-reqseq';
 
 import { editWorksitePlan } from './WorksitePlanActions';
 import { isDefined } from '../../../utils/LangUtils';
-import {
-  getEntityProperties,
-  getEntityKeyId,
-  getEntitySetIdFromApp,
-  getPropertyTypeIdFromEdm
-} from '../../../utils/DataUtils';
+import { getEntityProperties, getEntityKeyId } from '../../../utils/DataUtils';
 import { APP_TYPE_FQNS, PROPERTY_TYPE_FQNS } from '../../../core/edm/constants/FullyQualifiedNames';
 import { WORKSITE_ENROLLMENT_STATUSES } from '../../../core/edm/constants/DataModelConsts';
-import { STATE } from '../../../utils/constants/ReduxStateConsts';
+import { APP, EDM, STATE } from '../../../utils/constants/ReduxStateConsts';
 import {
   ButtonsRow,
   FormRow,
@@ -48,6 +43,8 @@ const {
   REQUIRED_HOURS,
   STATUS,
 } = PROPERTY_TYPE_FQNS;
+const { ENTITY_SET_IDS_BY_ORG, SELECTED_ORG_ID } = APP;
+const { PROPERTY_TYPES, TYPE_IDS_BY_FQNS } = EDM;
 
 const STATUS_OPTIONS :Object[] = Object.values(WORKSITE_ENROLLMENT_STATUSES)
   .map((statusName) => ({ label: statusName, value: statusName }));
@@ -56,8 +53,8 @@ type Props = {
   actions:{
     editWorksitePlan :RequestSequence;
   };
-  app :Map;
-  edm :Map;
+  entitySetIds :Map;
+  propertyTypeIds :Map;
   isLoading :boolean;
   onDiscard :() => void;
   worksitePlan :Map;
@@ -95,8 +92,8 @@ class EditWorksitePlanForm extends Component<Props, State> {
   handleOnSubmit = () => {
     const {
       actions,
-      app,
-      edm,
+      entitySetIds,
+      propertyTypeIds,
       worksitePlan,
     } = this.props;
     const { hoursWorked, newStatus, requiredHours } = this.state;
@@ -104,9 +101,9 @@ class EditWorksitePlanForm extends Component<Props, State> {
     const worksitePlanEKID :UUID = getEntityKeyId(worksitePlan);
     const nowAsIso = DateTime.local().toISO();
 
-    const worksitePlanESID :UUID = getEntitySetIdFromApp(app, WORKSITE_PLAN);
-    const hoursWorkedPTID :UUID = getPropertyTypeIdFromEdm(edm, HOURS_WORKED);
-    const requiredHoursPTID :UUID = getPropertyTypeIdFromEdm(edm, REQUIRED_HOURS);
+    const worksitePlanESID :UUID = entitySetIds.get(WORKSITE_PLAN);
+    const hoursWorkedPTID :UUID = propertyTypeIds.get(HOURS_WORKED);
+    const requiredHoursPTID :UUID = propertyTypeIds.get(REQUIRED_HOURS);
 
     let statusEntityData :{} = {};
     let statusAssociationData :{} = {};
@@ -133,16 +130,6 @@ class EditWorksitePlanForm extends Component<Props, State> {
       });
       const associations = [];
       associations.push([RELATED_TO, worksitePlanEKID, WORKSITE_PLAN, 0, ENROLLMENT_STATUS, {}]);
-
-      const entitySetIds :Object = {
-        [ENROLLMENT_STATUS]: getEntitySetIdFromApp(app, ENROLLMENT_STATUS),
-        [RELATED_TO]: getEntitySetIdFromApp(app, RELATED_TO),
-        [WORKSITE_PLAN]: getEntitySetIdFromApp(app, WORKSITE_PLAN),
-      };
-      const propertyTypeIds :Object = {
-        [EFFECTIVE_DATE]: getPropertyTypeIdFromEdm(edm, EFFECTIVE_DATE),
-        [STATUS]: getPropertyTypeIdFromEdm(edm, STATUS),
-      };
 
       statusEntityData = processEntityData(newStatusData, entitySetIds, propertyTypeIds);
       statusAssociationData = processAssociationEntityData(
@@ -217,10 +204,15 @@ class EditWorksitePlanForm extends Component<Props, State> {
   }
 }
 
-const mapStateToProps = (state :Map) => ({
-  app: state.get(STATE.APP),
-  edm: state.get(STATE.EDM),
-});
+const mapStateToProps = (state :Map) => {
+  const app = state.get(STATE.APP);
+  const edm = state.get(STATE.EDM);
+  const selectedOrgId :string = app.get(SELECTED_ORG_ID);
+  return ({
+    entitySetIds: app.getIn([ENTITY_SET_IDS_BY_ORG, selectedOrgId], Map()),
+    propertyTypeIds: edm.getIn([TYPE_IDS_BY_FQNS, PROPERTY_TYPES], Map()),
+  });
+};
 
 const mapDispatchToProps = (dispatch) => ({
   actions: bindActionCreators({

--- a/src/containers/participant/cases/AssignJudgeForm.js
+++ b/src/containers/participant/cases/AssignJudgeForm.js
@@ -116,26 +116,26 @@ class AssignJudgeForm extends Component<Props, State> {
     const diversionPlanEKID = getEntityKeyId(diversionPlan);
 
     const associationEntityData :{} = {
-      [entitySetIds[PRESIDES_OVER]]: [
+      [entitySetIds.get(PRESIDES_OVER)]: [
         {
           data: {},
           dst: {
-            entitySetId: entitySetIds[MANUAL_PRETRIAL_COURT_CASES],
+            entitySetId: entitySetIds.get(MANUAL_PRETRIAL_COURT_CASES),
             entityKeyId: caseEKID
           },
           src: {
-            entitySetId: entitySetIds[JUDGES],
+            entitySetId: entitySetIds.get(JUDGES),
             entityKeyId: judgeEKID
           }
         },
         {
           data: {},
           dst: {
-            entitySetId: entitySetIds[DIVERSION_PLAN],
+            entitySetId: entitySetIds.get(DIVERSION_PLAN),
             entityKeyId: diversionPlanEKID
           },
           src: {
-            entitySetId: entitySetIds[JUDGES],
+            entitySetId: entitySetIds.get(JUDGES),
             entityKeyId: judgeEKID
           }
         }

--- a/src/containers/participant/cases/EditCaseForm.js
+++ b/src/containers/participant/cases/EditCaseForm.js
@@ -75,7 +75,7 @@ class EditCaseForm extends Component<Props, State> {
     const { [CASE_NUMBER_TEXT]: caseNumbers, [COURT_CASE_TYPE]: courtCaseType } = getEntityProperties(
       personCase, [CASE_NUMBER_TEXT, COURT_CASE_TYPE]
     );
-    const casePrepopulated = !!caseNumbers || !!courtCaseType;
+    const casePrepopulated = !personCase.isEmpty();
     const caseFormData :{} = casePrepopulated
       ? {
         [sectionOneKey]: {

--- a/src/containers/participant/cases/EditChargesForm.js
+++ b/src/containers/participant/cases/EditChargesForm.js
@@ -137,8 +137,8 @@ class EditChargesForm extends Component<Props, State> {
         chargesFormData[sectionOneKey][index][getEntityAddressKey(-1, COURT_CHARGE_LIST, ENTITY_KEY_ID)] = chargeEKID;
         chargesFormData[sectionOneKey][index][getEntityAddressKey(-1, CHARGE_EVENT, DATETIME_COMPLETED)] = dateCharged;
       });
-      newChargeSchema = hydrateChargeSchema(chargeSchema, charges);
     }
+    newChargeSchema = hydrateChargeSchema(chargeSchema, charges);
 
 
     this.setState({
@@ -179,8 +179,8 @@ class EditChargesForm extends Component<Props, State> {
 
     const personEKID = getEntityKeyId(participant);
     const caseEKID = getEntityKeyId(personCase);
-    const courtChargeListESID :UUID = entitySetIds[COURT_CHARGE_LIST];
-    const olEKID :UUID = propertyTypeIds[ENTITY_KEY_ID];
+    const courtChargeListESID :UUID = entitySetIds.get(COURT_CHARGE_LIST);
+    const olEKID :UUID = propertyTypeIds.get(ENTITY_KEY_ID);
 
     fromJS(entityData).get(courtChargeListESID).forEach((courtCharge :Map, index :number) => {
       const courtChargeEKID :UUID = courtCharge.getIn([olEKID, 0]);

--- a/src/containers/participant/cases/EditRequiredHoursForm.js
+++ b/src/containers/participant/cases/EditRequiredHoursForm.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import { Map, has } from 'immutable';
+import { Map } from 'immutable';
 import { Card, CardHeader } from 'lattice-ui-kit';
 import { Form, DataProcessingUtils } from 'lattice-fabricate';
 import { connect } from 'react-redux';
@@ -37,14 +37,12 @@ type Props = {
 
 type State = {
   requiredHoursFormData :Object;
-  requiredHoursPrepopulated :boolean;
 };
 
 class EditRequiredHoursForm extends Component<Props, State> {
 
   state = {
     requiredHoursFormData: {},
-    requiredHoursPrepopulated: false,
   };
 
   componentDidMount() {
@@ -62,20 +60,14 @@ class EditRequiredHoursForm extends Component<Props, State> {
     const { diversionPlan } = this.props;
 
     const sectionOneKey = getPageSectionKey(1, 1);
-    const requiredHoursPrepopulated = has(diversionPlan, REQUIRED_HOURS);
     const { [REQUIRED_HOURS]: requiredHours } = getEntityProperties(diversionPlan, [REQUIRED_HOURS]);
-    const requiredHoursFormData :{} = requiredHoursPrepopulated
-      ? {
-        [sectionOneKey]: {
-          [getEntityAddressKey(0, DIVERSION_PLAN, REQUIRED_HOURS)]: requiredHours
-        }
+    const requiredHoursFormData :{} = {
+      [sectionOneKey]: {
+        [getEntityAddressKey(0, DIVERSION_PLAN, REQUIRED_HOURS)]: requiredHours
       }
-      : {};
+    };
 
-    this.setState({
-      requiredHoursFormData,
-      requiredHoursPrepopulated,
-    });
+    this.setState({ requiredHoursFormData });
   }
 
   render() {
@@ -87,7 +79,6 @@ class EditRequiredHoursForm extends Component<Props, State> {
     } = this.props;
     const {
       requiredHoursFormData,
-      requiredHoursPrepopulated,
     } = this.state;
 
     const requiredHoursFormContext = {
@@ -102,7 +93,7 @@ class EditRequiredHoursForm extends Component<Props, State> {
       <Card>
         <CardHeader padding="sm">Edit Required Hours</CardHeader>
         <Form
-            disabled={requiredHoursPrepopulated}
+            disabled
             formContext={requiredHoursFormContext}
             formData={requiredHoursFormData}
             schema={requiredHoursSchema}
@@ -112,7 +103,7 @@ class EditRequiredHoursForm extends Component<Props, State> {
   }
 }
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = (dispatch) => ({
   actions: bindActionCreators({
     editRequiredHours,
   }, dispatch)


### PR DESCRIPTION
Fixes bugs:

- Was still trying to read values from entitySetIds and propertyTypeIds as if they were objects rather than Maps in some places.
- Wasn't pre-populating blank case entity, which was a problem, because the form then treated entering case info like a first-time submission.
- Required hours form always needs to be an "edit" (and not first-time submission, even if it's an empty property), because diversion plan should/will always exist.
- ESIDs map and PTIDs map stored in state wasn't being used in every form and now is.