### PR TITLE
2020-02-11 release

### DIFF
--- a/src/containers/participant/EditEnrollmentDatesForm.js
+++ b/src/containers/participant/EditEnrollmentDatesForm.js
@@ -14,18 +14,12 @@ import type { Match } from 'react-router';
 import LogoLoader from '../../components/LogoLoader';
 
 import * as Routes from '../../core/router/Routes';
-import {
-  editEnrollmentDates,
-  getEnrollmentStatus,
-} from './ParticipantActions';
-import { goToRoute } from '../../core/router/RoutingActions';
-import { APP_TYPE_FQNS, PROPERTY_TYPE_FQNS } from '../../core/edm/constants/FullyQualifiedNames';
-import {
-  schema,
-  uiSchema,
-} from './schemas/EditEnrollmentDatesSchemas';
-import { getEntityKeyId, getEntityProperties } from '../../utils/DataUtils';
 import { BackNavButton } from '../../components/controls/index';
+import { editEnrollmentDates, getDiversionPlan } from './ParticipantActions';
+import { goToRoute } from '../../core/router/RoutingActions';
+import { schema, uiSchema } from './schemas/EditEnrollmentDatesSchemas';
+import { getEntityKeyId, getEntityProperties } from '../../utils/DataUtils';
+import { APP_TYPE_FQNS, PROPERTY_TYPE_FQNS } from '../../core/edm/constants/FullyQualifiedNames';
 import { PARTICIPANT_PROFILE_WIDTH } from '../../core/style/Sizes';
 import {
   APP,
@@ -49,7 +43,7 @@ const { ENTITY_SET_IDS_BY_ORG, SELECTED_ORG_ID } = APP;
 const { PROPERTY_TYPES, TYPE_IDS_BY_FQNS } = EDM;
 const {
   ACTIONS,
-  GET_ENROLLMENT_STATUS,
+  GET_DIVERSION_PLAN,
   REQUEST_STATE,
 } = PERSON;
 
@@ -69,12 +63,12 @@ const ButtonWrapper = styled.div`
 type Props = {
   actions:{
     editEnrollmentDates :RequestSequence;
-    getEnrollmentStatus :RequestSequence;
+    getDiversionPlan :RequestSequence;
     goToRoute :GoToRoute;
   },
   diversionPlan :Map;
   entitySetIds :Map;
-  getEnrollmentStatusRequestState :RequestState;
+  getDiversionPlanRequestState :RequestState;
   initializeAppRequestState :RequestState;
   match :Match;
   propertyTypeIds :Map;
@@ -99,11 +93,11 @@ class EditCaseInfoForm extends Component<Props, State> {
       actions,
       entitySetIds,
       match: {
-        params: { participantId: personEKID }
+        params: { diversionPlanId: diversionPlanEKID }
       },
     } = this.props;
-    if (entitySetIds.has(DIVERSION_PLAN) && personEKID) {
-      actions.getEnrollmentStatus({ personEKID });
+    if (entitySetIds.has(DIVERSION_PLAN) && diversionPlanEKID) {
+      actions.getDiversionPlan({ diversionPlanEKID });
     }
   }
 
@@ -112,16 +106,16 @@ class EditCaseInfoForm extends Component<Props, State> {
       actions,
       entitySetIds,
       diversionPlan,
-      getEnrollmentStatusRequestState,
+      getDiversionPlanRequestState,
       match: {
-        params: { participantId: personEKID }
+        params: { diversionPlanId: diversionPlanEKID }
       },
     } = this.props;
-    if ((!prevProps.entitySetIds.has(DIVERSION_PLAN) && entitySetIds.has(DIVERSION_PLAN)) && personEKID) {
-      actions.getEnrollmentStatus({ personEKID, populateProfile: false });
+    if ((!prevProps.entitySetIds.has(DIVERSION_PLAN) && entitySetIds.has(DIVERSION_PLAN)) && diversionPlanEKID) {
+      actions.getDiversionPlan({ diversionPlanEKID });
     }
-    if ((prevProps.getEnrollmentStatusRequestState === RequestStates.PENDING
-      && getEnrollmentStatusRequestState !== RequestStates.PENDING)
+    if ((prevProps.getDiversionPlanRequestState === RequestStates.PENDING
+      && getDiversionPlanRequestState !== RequestStates.PENDING)
       || !prevProps.diversionPlan.equals(diversionPlan)) {
       this.prepopulateFormData();
     }
@@ -198,14 +192,14 @@ class EditCaseInfoForm extends Component<Props, State> {
     const {
       actions,
       entitySetIds,
-      getEnrollmentStatusRequestState,
+      getDiversionPlanRequestState,
       initializeAppRequestState,
       propertyTypeIds,
     } = this.props;
     const { formData } = this.state;
 
     if (initializeAppRequestState === RequestStates.PENDING
-      || getEnrollmentStatusRequestState === RequestStates.PENDING) {
+      || getDiversionPlanRequestState === RequestStates.PENDING) {
       return (
         <LogoLoader
             loadingText="Please wait..."
@@ -254,7 +248,7 @@ const mapStateToProps = (state :Map) => {
   return ({
     [PERSON.DIVERSION_PLAN]: person.get(PERSON.DIVERSION_PLAN),
     entitySetIds: app.getIn([ENTITY_SET_IDS_BY_ORG, selectedOrgId], Map()),
-    getEnrollmentStatusRequestState: person.getIn([ACTIONS, GET_ENROLLMENT_STATUS, REQUEST_STATE]),
+    getDiversionPlanRequestState: person.getIn([ACTIONS, GET_DIVERSION_PLAN, REQUEST_STATE]),
     initializeAppRequestState: app.getIn([APP.ACTIONS, APP.INITIALIZE_APPLICATION, APP.REQUEST_STATE]),
     propertyTypeIds: edm.getIn([TYPE_IDS_BY_FQNS, PROPERTY_TYPES], Map()),
   });
@@ -263,7 +257,7 @@ const mapStateToProps = (state :Map) => {
 const mapDispatchToProps = (dispatch) => ({
   actions: bindActionCreators({
     editEnrollmentDates,
-    getEnrollmentStatus,
+    getDiversionPlan,
     goToRoute,
   }, dispatch)
 });

--- a/src/containers/participant/ParticipantActions.js
+++ b/src/containers/participant/ParticipantActions.js
@@ -47,6 +47,9 @@ const getCaseInfo :RequestSequence = newRequestSequence(GET_CASE_INFO);
 const GET_CONTACT_INFO :'GET_CONTACT_INFO' = 'GET_CONTACT_INFO';
 const getContactInfo :RequestSequence = newRequestSequence(GET_CONTACT_INFO);
 
+const GET_DIVERSION_PLAN :'GET_DIVERSION_PLAN' = 'GET_DIVERSION_PLAN';
+const getDiversionPlan :RequestSequence = newRequestSequence(GET_DIVERSION_PLAN);
+
 const GET_ENROLLMENT_HISTORY :'GET_ENROLLMENT_HISTORY' = 'GET_ENROLLMENT_HISTORY';
 const getEnrollmentHistory :RequestSequence = newRequestSequence(GET_ENROLLMENT_HISTORY);
 
@@ -111,8 +114,9 @@ export {
   GET_ALL_PARTICIPANT_INFO,
   GET_CASE_INFO,
   GET_CONTACT_INFO,
-  GET_ENROLLMENT_HISTORY,
+  GET_DIVERSION_PLAN,
   GET_ENROLLMENT_FROM_DIVERSION_PLAN,
+  GET_ENROLLMENT_HISTORY,
   GET_ENROLLMENT_STATUS,
   GET_INFO_FOR_ADD_PARTICIPANT,
   GET_INFO_FOR_EDIT_CASE,
@@ -142,8 +146,9 @@ export {
   getAllParticipantInfo,
   getCaseInfo,
   getContactInfo,
-  getEnrollmentHistory,
+  getDiversionPlan,
   getEnrollmentFromDiversionPlan,
+  getEnrollmentHistory,
   getEnrollmentStatus,
   getInfoForAddParticipant,
   getInfoForEditCase,

--- a/src/containers/participant/ParticipantProfile.js
+++ b/src/containers/participant/ParticipantProfile.js
@@ -349,8 +349,11 @@ class ParticipantProfile extends Component<Props, State> {
   }
 
   editEnrollmentDates = () => {
-    const { actions, personEKID } = this.props;
-    actions.goToRoute(Routes.EDIT_DATES.replace(':participantId', personEKID));
+    const { actions, diversionPlan, personEKID } = this.props;
+    const diversionPlanEKID :UUID = getEntityKeyId(diversionPlan);
+    actions.goToRoute(Routes.EDIT_DATES
+      .replace(':participantId', personEKID)
+      .replace(':diversionPlanId', diversionPlanEKID));
   }
 
   goToNewEnrollmentForm = () => {

--- a/src/containers/participant/ParticipantReducer.js
+++ b/src/containers/participant/ParticipantReducer.js
@@ -25,6 +25,7 @@ import {
   getAllParticipantInfo,
   getCaseInfo,
   getContactInfo,
+  getDiversionPlan,
   getEnrollmentHistory,
   getEnrollmentFromDiversionPlan,
   getEnrollmentStatus,
@@ -92,6 +93,7 @@ const {
   GET_ALL_PARTICIPANT_INFO,
   GET_CASE_INFO,
   GET_CONTACT_INFO,
+  GET_DIVERSION_PLAN,
   GET_ENROLLMENT_HISTORY,
   GET_ENROLLMENT_FROM_DIVERSION_PLAN,
   GET_ENROLLMENT_STATUS,
@@ -161,6 +163,9 @@ const INITIAL_STATE :Map<*, *> = fromJS({
       [REQUEST_STATE]: RequestStates.STANDBY
     },
     [GET_CONTACT_INFO]: {
+      [REQUEST_STATE]: RequestStates.STANDBY
+    },
+    [GET_DIVERSION_PLAN]: {
       [REQUEST_STATE]: RequestStates.STANDBY
     },
     [GET_ENROLLMENT_HISTORY]: {
@@ -716,6 +721,26 @@ export default function participantReducer(state :Map<*, *> = INITIAL_STATE, act
         FAILURE: () => state
           .setIn([ACTIONS, GET_CONTACT_INFO, REQUEST_STATE], RequestStates.FAILURE),
         FINALLY: () => state.deleteIn([ACTIONS, GET_CONTACT_INFO, action.id])
+      });
+    }
+
+    case getDiversionPlan.case(action.type): {
+
+      return getDiversionPlan.reducer(state, action, {
+
+        REQUEST: () => state
+          .setIn([ACTIONS, GET_DIVERSION_PLAN, action.id], fromJS(action))
+          .setIn([ACTIONS, GET_DIVERSION_PLAN, REQUEST_STATE], RequestStates.PENDING),
+        SUCCESS: () => {
+          const seqAction :SequenceAction = action;
+          const { value } = seqAction;
+          return state
+            .set(DIVERSION_PLAN, value)
+            .setIn([ACTIONS, GET_DIVERSION_PLAN, REQUEST_STATE], RequestStates.SUCCESS);
+        },
+        FAILURE: () => state
+          .setIn([ACTIONS, GET_DIVERSION_PLAN, REQUEST_STATE], RequestStates.FAILURE),
+        FINALLY: () => state.deleteIn([ACTIONS, GET_DIVERSION_PLAN, action.id])
       });
     }
 

--- a/src/core/router/Routes.js
+++ b/src/core/router/Routes.js
@@ -16,7 +16,7 @@ export const PRINT_PARTICIPANT_SCHEDULE :string = `${PARTICIPANT_PROFILE}/schedu
 const EDIT_PROFILE :string = `${PARTICIPANT_PROFILE}/edit`;
 export const EDIT_PARTICIPANT :string = `${EDIT_PROFILE}/participant`;
 export const EDIT_CASE_INFO :string = `${EDIT_PROFILE}/caseinfo`;
-export const EDIT_DATES :string = `${EDIT_PROFILE}/enrollmentdates`;
+export const EDIT_DATES :string = `${EDIT_PROFILE}/enrollmentdates/:diversionPlanId`;
 export const PRINT_INFRACTION :string = `${PARTICIPANT_PROFILE}/infraction/:infractionId/print`;
 export const CREATE_NEW_ENROLLMENT :string = `${PARTICIPANT_PROFILE}/createnewenrollment`;
 

--- a/src/core/sagas/Sagas.js
+++ b/src/core/sagas/Sagas.js
@@ -85,6 +85,7 @@ export default function* sagas() :Generator<*, *, *> {
     fork(ParticipantSagas.getAllParticipantInfoWatcher),
     fork(ParticipantSagas.getCaseInfoWatcher),
     fork(ParticipantSagas.getContactInfoWatcher),
+    fork(ParticipantSagas.getDiversionPlanWatcher),
     fork(ParticipantSagas.getEnrollmentHistoryWatcher),
     fork(ParticipantSagas.getEnrollmentFromDiversionPlanWatcher),
     fork(ParticipantSagas.getEnrollmentStatusWatcher),

--- a/src/utils/constants/ReduxStateConsts.js
+++ b/src/utils/constants/ReduxStateConsts.js
@@ -139,6 +139,7 @@ export const PERSON = {
   GET_ALL_PARTICIPANT_INFO: 'getAllParticipantInfo',
   GET_CASE_INFO: 'getCaseInfo',
   GET_CONTACT_INFO: 'getContactInfo',
+  GET_DIVERSION_PLAN: 'getDiversionPlan',
   GET_ENROLLMENT_HISTORY: 'getEnrollmentHistory',
   GET_ENROLLMENT_FROM_DIVERSION_PLAN: 'getEnrollmentFromDiversionPlan',
   GET_ENROLLMENT_STATUS: 'getEnrollmentStatus',


### PR DESCRIPTION
There was a bug with fetching the diversion plan in the `EditEnrollmentDatesForm`. The form was calling the `getEnrollmentStatus` saga, which would grab the most recent diversion plan instead of the one that was just displayed on the person profile before navigating to the form. So now the diversion plan EKID is passed through the URL and entity is fetched in the form.