### PR TITLE
Bugfix/APPS-1964 — fix arrest charges creation and display

### DIFF
--- a/src/containers/participant/ParticipantSagas.js
+++ b/src/containers/participant/ParticipantSagas.js
@@ -1793,7 +1793,7 @@ function* getPersonPhotoWatcher() :Generator<*, *, *> {
 function* getInfoForEditCaseWorker(action :SequenceAction) :Generator<*, *, *> {
 
   const { id, value } = action;
-  if (value === null || value === undefined) {
+  if (!isDefined(value)) {
     yield put(getInfoForEditCase.failure(id, ERR_ACTION_VALUE_NOT_DEFINED));
     return;
   }

--- a/src/containers/participant/cases/EditArrestChargesForm.js
+++ b/src/containers/participant/cases/EditArrestChargesForm.js
@@ -24,9 +24,7 @@ import AddToAvailableArrestChargesModal from '../charges/AddToAvailableArrestCha
 import { addArrestCharges, removeArrestCharge } from '../charges/ChargesActions';
 import { arrestChargeSchema, arrestChargeUiSchema } from './schemas/EditCaseInfoSchemas';
 import { hydrateArrestChargeSchema } from './utils/EditCaseInfoUtils';
-import { getCombinedDateTime } from '../../../utils/ScheduleUtils';
 import { getEntityKeyId, getEntityProperties } from '../../../utils/DataUtils';
-import { isDefined } from '../../../utils/LangUtils';
 import {
   formatExistingChargeDataAndAssociation,
   formatNewArrestChargeDataAndAssociations,
@@ -45,13 +43,10 @@ const {
   ARREST_CHARGE_LIST,
   MANUAL_ARREST_CASES,
   MANUAL_ARREST_CHARGES,
-  MANUAL_CHARGED_WITH,
   PEOPLE,
-  REGISTERED_FOR,
-  RELATED_TO,
   DIVERSION_PLAN,
 } = APP_TYPE_FQNS;
-const { ARREST_DATETIME, DATETIME_COMPLETED, ENTITY_KEY_ID } = PROPERTY_TYPE_FQNS;
+const { DATETIME_COMPLETED, ENTITY_KEY_ID } = PROPERTY_TYPE_FQNS;
 
 const getDateChargedFromChargeEvent = (chargeEvent :Map) :string => {
   const { [DATETIME_COMPLETED]: dateTimeCharged } = getEntityProperties(chargeEvent, [DATETIME_COMPLETED]);
@@ -92,7 +87,7 @@ type State = {
   isAvailableChargesModalVisible :boolean;
 };
 
-class EditCourtChargesForm extends Component<Props, State> {
+class EditArrestChargesForm extends Component<Props, State> {
 
   constructor(props :Props) {
     super(props);
@@ -226,10 +221,8 @@ class EditCourtChargesForm extends Component<Props, State> {
       });
       mappers.set(INDEX_MAPPERS, indexMappers);
     });
-
     const entityData :{} = processEntityData(entities, entitySetIds, propertyTypeIds, entityMappers);
     const associationEntityData :{} = processAssociationEntityData(fromJS(associations), entitySetIds, propertyTypeIds);
-
     actions.addArrestCharges({ associationEntityData, entityData });
   }
 
@@ -363,4 +356,4 @@ const mapDispatchToProps = (dispatch) => ({
 });
 
 // $FlowFixMe
-export default connect(null, mapDispatchToProps)(EditCourtChargesForm);
+export default connect(null, mapDispatchToProps)(EditArrestChargesForm);

--- a/src/containers/participant/charges/utils/ChargesUtils.js
+++ b/src/containers/participant/charges/utils/ChargesUtils.js
@@ -70,6 +70,14 @@ const formatNewArrestChargeDataAndAssociations = (
       arrestChargeEKID,
       ARREST_CHARGE_LIST
     ]);
+
+    newChargeAssociations.push([
+      APPEARS_IN,
+      index + numberOfExistingChargesAdded,
+      CHARGE_EVENT,
+      index,
+      MANUAL_ARREST_CASES
+    ]);
     newChargeAssociations.push([APPEARS_IN, arrestChargeEKID, ARREST_CHARGE_LIST, index, MANUAL_ARREST_CASES]);
     newChargeAssociations.push([APPEARS_IN_ARREST, personIndexOrEKID, PEOPLE, index, MANUAL_ARREST_CASES]);
     newChargeAssociations.push([MANUAL_CHARGED_WITH, personIndexOrEKID, PEOPLE, arrestChargeEKID, ARREST_CHARGE_LIST]);
@@ -81,6 +89,13 @@ const formatNewArrestChargeDataAndAssociations = (
       CHARGE_EVENT
     ]);
     newChargeAssociations.push([RELATED_TO, diversionPlanIndexOrEKID, DIVERSION_PLAN, index, MANUAL_ARREST_CASES]);
+    newChargeAssociations.push([
+      RELATED_TO,
+      diversionPlanIndexOrEKID,
+      DIVERSION_PLAN,
+      index + numberOfExistingChargesAdded,
+      CHARGE_EVENT
+    ]);
   });
 
   return { newChargeEntities, newChargeAssociations };


### PR DESCRIPTION
There was an issue with the New Arrest Charge form in the profile: Adding a charge appeared to add multiple of the same charge, and removing a charge appeared to remove all of the instances of that charge. What was actually happening was that the form was displaying all `charge event` entities tied to that charge entity from `arrest charge list`, even if the charge event was not tied to the person whose profile you were on. Furthermore, it was virtually impossible to correctly display the person's charge events in the profile without an association between the `arrest case` and `charge event`, so I added `charge event -> appears in -> arrest case` to all the existing charge event entities and to the submission workflow. Lastly, I added `diversion plan -> related to -> charge event` to existing entities and submission workflow to create a 1-degree separation (instead of 2) from diversion plan to arrest charge event, because number of diversion plans per arrest charge will be needed for the stats dashboard.

<img width="1040" alt="Screen Shot 2020-04-27 at 6 59 41 PM" src="https://user-images.githubusercontent.com/32921059/80440651-15da1900-88be-11ea-86d9-105acc7f5a13.png">
