### PR TITLE
bugfix/APPS-2108 — calculate hours correctly

### DIFF
--- a/src/containers/stats/courttype/CourtTypeSagas.js
+++ b/src/containers/stats/courttype/CourtTypeSagas.js
@@ -616,6 +616,15 @@ function* getMonthlyParticipantsByCourtTypeWorker(action :SequenceAction) :Gener
               .find((participantMap :Map) => participantMap.get('personName') === personName)) {
               listOfParticipantsAndTheirHours = listOfParticipantsAndTheirHours.push(fromJS({ personName, hours }));
             }
+            else {
+              const participantIndex :number = listOfParticipantsAndTheirHours
+                .findIndex((participantMap :Map) => participantMap.get('personName') === personName);
+              listOfParticipantsAndTheirHours = listOfParticipantsAndTheirHours
+                .setIn(
+                  [participantIndex, 'hours'],
+                  listOfParticipantsAndTheirHours.getIn([participantIndex, 'hours']) + hours
+                );
+            }
             monthlyParticipantsByCourtType = monthlyParticipantsByCourtType
               .set(courtType, listOfParticipantsAndTheirHours);
           }


### PR DESCRIPTION
previously was not adding all hours found from check-ins together for Monthly Participants By Court Type graph—was just taking hours from the first check-in.