### PR TITLE
Bugfix/APPS-2633 — phone numbers not saving

### DIFF
--- a/src/containers/participant/contacts/PersonContactsReducer.js
+++ b/src/containers/participant/contacts/PersonContactsReducer.js
@@ -152,8 +152,8 @@ export default function participantReducer(state :Map<*, *> = INITIAL_STATE, act
           .setIn([ACTIONS, GET_PERSON_CONTACT_INFO, action.id], fromJS(action))
           .setIn([ACTIONS, GET_PERSON_CONTACT_INFO, REQUEST_STATE], RequestStates.PENDING),
         SUCCESS: () => state
-          .set(EMAIL, action.value.get(CONTACT_METHODS.EMAIL, Map()))
-          .set(PHONE, action.value.get(CONTACT_METHODS.PHONE, Map()))
+          .set(EMAIL, action.value.activeEmail)
+          .set(PHONE, action.value.activePhone)
           .setIn([ACTIONS, GET_PERSON_CONTACT_INFO, REQUEST_STATE], RequestStates.SUCCESS),
         FAILURE: () => state
           .setIn([ACTIONS, GET_PERSON_CONTACT_INFO, REQUEST_STATE], RequestStates.FAILURE),

--- a/src/containers/participant/contacts/PersonContactsReducer.js
+++ b/src/containers/participant/contacts/PersonContactsReducer.js
@@ -22,7 +22,6 @@ import {
   getPersonContactInfo,
 } from './PersonContactsActions';
 
-import { CONTACT_METHODS } from '../../../core/edm/constants/DataModelConsts';
 import { PERSON_CONTACTS, SHARED } from '../../../utils/constants/ReduxStateConsts';
 
 const { EMAIL, PERSON_ADDRESS, PHONE } = PERSON_CONTACTS;

--- a/src/containers/participant/contacts/PersonContactsSagas.js
+++ b/src/containers/participant/contacts/PersonContactsSagas.js
@@ -57,8 +57,8 @@ const { ADDRESS, CONTACT_INFORMATION, PEOPLE } = APP_TYPE_FQNS;
 const {
   EMAIL,
   ENTITY_KEY_ID,
+  INACTIVE,
   PHONE_NUMBER,
-  PREFERRED,
 } = PROPERTY_TYPE_FQNS;
 const getAppFromState = (state) => state.get(STATE.APP, Map());
 const getEdmFromState = (state) => state.get(STATE.EDM, Map());
@@ -437,26 +437,28 @@ function* getPersonContactInfoWorker(action :SequenceAction) :Generator<*, *, *>
     );
     if (response.error) throw response.error;
 
-    const contactInfo :Map = Map().withMutations((mutator :Map) => {
+    const contactInfoList :List = List().withMutations((mutator :List) => {
       if (response.data[personEKID]) {
-        fromJS(response.data[personEKID])
-          .map((contactInfoNeighbor :Map) => getNeighborDetails(contactInfoNeighbor))
-          .forEach((contact :Map) => {
-            const { [PREFERRED]: preferred } = getEntityProperties(contact, [PREFERRED]);
-            let email :Map = mutator.get(CONTACT_METHODS.EMAIL, Map());
-            let phone :Map = mutator.get(CONTACT_METHODS.PHONE, Map());
-            if (contact.get(PHONE_NUMBER) && preferred) {
-              phone = contact;
-            }
-            if (contact.get(EMAIL) && preferred) {
-              email = contact;
-            }
-            mutator.set(CONTACT_METHODS.EMAIL, email);
-            mutator.set(CONTACT_METHODS.PHONE, phone);
-          });
+        fromJS(response.data[personEKID]).forEach((contactInfoNeighbor :Map) => {
+          mutator.push(getNeighborDetails(contactInfoNeighbor));
+        });
       }
     });
-    yield put(getPersonContactInfo.success(id, contactInfo));
+
+    const allPhoneNumbers :List = contactInfoList.filter((contact :Map) => contact.has(PHONE_NUMBER));
+    const allEmails :List = contactInfoList.filter((contact :Map) => contact.has(EMAIL));
+
+    const activePhone = allPhoneNumbers.find((contact :Map) => {
+      const { [INACTIVE]: inactive } = getEntityProperties(contact, [INACTIVE]);
+      return contact.get(INACTIVE) && isDefined(inactive) && !inactive;
+    }) || Map();
+
+    const activeEmail = allEmails.find((contact :Map) => {
+      const { [INACTIVE]: inactive } = getEntityProperties(contact, [INACTIVE]);
+      return contact.get(INACTIVE) && isDefined(inactive) && !inactive;
+    }) || Map();
+
+    yield put(getPersonContactInfo.success(id, { activeEmail, activePhone }));
   }
   catch (error) {
     workerResponse.error = error;

--- a/src/containers/participant/contacts/PersonContactsSagas.js
+++ b/src/containers/participant/contacts/PersonContactsSagas.js
@@ -37,7 +37,6 @@ import {
   getPersonContactInfo,
 } from './PersonContactsActions';
 
-import { CONTACT_METHODS } from '../../../core/edm/constants/DataModelConsts';
 import { APP_TYPE_FQNS, PROPERTY_TYPE_FQNS } from '../../../core/edm/constants/FullyQualifiedNames';
 import { submitDataGraph, submitPartialReplace } from '../../../core/sagas/data/DataActions';
 import { submitDataGraphWorker, submitPartialReplaceWorker } from '../../../core/sagas/data/DataSagas';

--- a/src/containers/participants/newparticipant/AddParticipantForm.js
+++ b/src/containers/participants/newparticipant/AddParticipantForm.js
@@ -92,11 +92,11 @@ const {
   EMAIL,
   ENTITY_KEY_ID,
   FULL_ADDRESS,
+  INACTIVE,
   LAST_NAME,
   NAME,
   ORIENTATION_DATETIME,
   PHONE_NUMBER,
-  PREFERRED,
   STATUS,
 } = PROPERTY_TYPE_FQNS;
 const {
@@ -319,13 +319,13 @@ class AddParticipantForm extends Component<Props, State> {
       dataToSubmit = setIn(dataToSubmit, [sectionTwo, addressKey], getIn(dataToSubmit, [sectionTwo, addressKey]) || '');
       dataToSubmit = setIn(
         dataToSubmit,
-        [getPageSectionKey(1, 2), getEntityAddressKey(0, CONTACT_INFORMATION, PREFERRED)],
-        true
+        [getPageSectionKey(1, 2), getEntityAddressKey(0, CONTACT_INFORMATION, INACTIVE)],
+        false
       );
       dataToSubmit = setIn(
         dataToSubmit,
-        [getPageSectionKey(1, 2), getEntityAddressKey(1, CONTACT_INFORMATION, PREFERRED)],
-        true
+        [getPageSectionKey(1, 2), getEntityAddressKey(1, CONTACT_INFORMATION, INACTIVE)],
+        false
       );
 
       associations.push([CONTACT_INFO_GIVEN, 0, CONTACT_INFORMATION, personIndexOrEKID, APP_TYPE_FQNS.PEOPLE, {}]);

--- a/src/core/edm/constants/FullyQualifiedNames.js
+++ b/src/core/edm/constants/FullyQualifiedNames.js
@@ -117,7 +117,6 @@ export const PROPERTY_TYPE_FQNS :Object = {
   PERSON_NOTES: FQN.of('housing.notes'),
   PHONE_NUMBER: FQN.of('contact.phonenumber'),
   PICTURE: FQN.of('person.picture'),
-  PREFERRED: FQN.of('ol.preferred'),
   RACE: FQN.of('nc.PersonRace'),
   REQUIRED_HOURS: FQN.of('ol.requiredhours'),
   REQUIRED_HOURS_TEXT: FQN.of('ol.requiredhourstext'),

--- a/src/core/edm/constants/FullyQualifiedNames.js
+++ b/src/core/edm/constants/FullyQualifiedNames.js
@@ -100,6 +100,7 @@ export const PROPERTY_TYPE_FQNS :Object = {
   GENDER: FQN.of('bhr.gender'),
   HOURS_WORKED: FQN.of('ol.hoursworked'),
   IMAGE_DATA: FQN.of('ol.imagedata'),
+  INACTIVE: FQN.of('ol.inactive'),
   INCIDENT_START_DATETIME: FQN.of('incident.startdatetime'),
   JUSTICE_XREF: FQN.of('justice.xref'),
   LAST_NAME: FQN.of('nc.PersonSurName'),

--- a/src/core/tracking/google/index.js
+++ b/src/core/tracking/google/index.js
@@ -4,6 +4,7 @@
 
 const GOOGLE_TRACKING_ID :'UA-118446829-6' = 'UA-118446829-6';
 
+/* eslint-disable import/prefer-default-export */
 export {
   GOOGLE_TRACKING_ID,
 };


### PR DESCRIPTION
This fix is to solve a conflict between integrated contact info entities and newly created contact info entities in CWP. There are often a bunch of integrated contact info entities associated with the integrated person before that person is added to CWP. A contact's `preferred` property type is sometimes edited in PCM or overwritten by an integration. However, CWP was also using the `preferred` property type on newly created entities and using it to determine which two contact entities (phone/email) were created by the CWP users and should be displayed in CWP. I updated the code to use the `inactive` property instead, which is not being used by PCM or in integrations, to be the marker for which contact info entities belong in CWP. I also updated all the existing contact info entities that have been created in CWP to have `inactive` = `false`, thus they will continue to be visible in the app as normal. There were also some person entities that were missing CWP contact info entities, so I created those too with `inactive` = `false`.

<img width="410" alt="Screen Shot 2020-12-15 at 3 19 54 PM" src="https://user-images.githubusercontent.com/32921059/102284438-04935a80-3ee9-11eb-804f-f5808889db67.png">
