### PR TITLE
Bugfix/APPS-2697 — contact info not saving

### DIFF
--- a/src/containers/participant/contacts/EditEmailForm.js
+++ b/src/containers/participant/contacts/EditEmailForm.js
@@ -2,7 +2,7 @@
 import React, { useEffect, useState } from 'react';
 
 import isEmpty from 'lodash/isEmpty';
-import { Map, fromJS } from 'immutable';
+import { Map, fromJS, setIn } from 'immutable';
 import { DataProcessingUtils, Form } from 'lattice-fabricate';
 import { Card, CardHeader } from 'lattice-ui-kit';
 import {
@@ -29,13 +29,14 @@ import { getContactFormData } from '../utils/EditContactsUtils';
 const { getEntityKeyId } = DataUtils;
 const { isDefined } = LangUtils;
 const {
+  getEntityAddressKey,
   getPageSectionKey,
   processAssociationEntityData,
   processEntityData,
 } = DataProcessingUtils;
 const { isPending } = ReduxUtils;
 const { CONTACT_INFORMATION, CONTACT_INFO_GIVEN, PEOPLE } = APP_TYPE_FQNS;
-const { EMAIL } = PROPERTY_TYPE_FQNS;
+const { EMAIL, INACTIVE } = PROPERTY_TYPE_FQNS;
 const { ENTITY_SET_IDS_BY_ORG, SELECTED_ORG_ID } = APP;
 const { PROPERTY_TYPES, TYPE_IDS_BY_FQNS } = EDM;
 const { ACTIONS } = SHARED;
@@ -81,7 +82,12 @@ const EditEmailForm = ({ email, participant } :Props) => {
   const onSubmit = ({ formData: submittedFormData }) => {
     if ((!isDefined(email) || email.isEmpty())
       && !isEmpty(submittedFormData[getPageSectionKey(1, 1)])) {
-      const entityData = processEntityData(submittedFormData, entitySetIds, propertyTypeIds);
+      const updatedFormData = setIn(
+        submittedFormData,
+        [getPageSectionKey(1, 1), getEntityAddressKey(0, CONTACT_INFORMATION, INACTIVE)],
+        false
+      );
+      const entityData = processEntityData(updatedFormData, entitySetIds, propertyTypeIds);
       const associations = [[CONTACT_INFO_GIVEN, 0, CONTACT_INFORMATION, personEKID, PEOPLE]];
       const associationEntityData = processAssociationEntityData(associations, entitySetIds, propertyTypeIds);
       dispatch(addPersonEmail({ associationEntityData, entityData }));

--- a/src/containers/participant/contacts/EditPhoneForm.js
+++ b/src/containers/participant/contacts/EditPhoneForm.js
@@ -2,7 +2,7 @@
 import React, { useEffect, useState } from 'react';
 
 import isEmpty from 'lodash/isEmpty';
-import { Map, fromJS } from 'immutable';
+import { Map, fromJS, setIn } from 'immutable';
 import { DataProcessingUtils, Form } from 'lattice-fabricate';
 import { Card, CardHeader } from 'lattice-ui-kit';
 import {
@@ -29,13 +29,14 @@ import { getContactFormData } from '../utils/EditContactsUtils';
 const { getEntityKeyId } = DataUtils;
 const { isDefined } = LangUtils;
 const {
+  getEntityAddressKey,
   getPageSectionKey,
   processAssociationEntityData,
   processEntityData,
 } = DataProcessingUtils;
 const { isPending } = ReduxUtils;
 const { CONTACT_INFORMATION, CONTACT_INFO_GIVEN, PEOPLE } = APP_TYPE_FQNS;
-const { PHONE_NUMBER } = PROPERTY_TYPE_FQNS;
+const { INACTIVE, PHONE_NUMBER } = PROPERTY_TYPE_FQNS;
 const { ENTITY_SET_IDS_BY_ORG, SELECTED_ORG_ID } = APP;
 const { PROPERTY_TYPES, TYPE_IDS_BY_FQNS } = EDM;
 const { ACTIONS } = SHARED;
@@ -81,7 +82,12 @@ const EditPhoneForm = ({ participant, phone } :Props) => {
   const onSubmit = ({ formData: submittedFormData }) => {
     if ((!isDefined(phone) || phone.isEmpty())
       && !isEmpty(submittedFormData[getPageSectionKey(1, 1)])) {
-      const entityData = processEntityData(submittedFormData, entitySetIds, propertyTypeIds);
+      const updatedFormData = setIn(
+        submittedFormData,
+        [getPageSectionKey(1, 1), getEntityAddressKey(0, CONTACT_INFORMATION, INACTIVE)],
+        false
+      );
+      const entityData = processEntityData(updatedFormData, entitySetIds, propertyTypeIds);
       const associations = [[CONTACT_INFO_GIVEN, 0, CONTACT_INFORMATION, personEKID, PEOPLE]];
       const associationEntityData = processAssociationEntityData(associations, entitySetIds, propertyTypeIds);
       dispatch(addPersonPhone({ associationEntityData, entityData }));


### PR DESCRIPTION
the issue was that submitting contact info in the form appeared to be working correctly, but then the phone number and/or email was not displaying on the profile (or back in the edit form) after navigating away. the bug was that the first-time submission of phone/email in the profile was not setting the `inactive` property to `false`, which is what distinguishes CWP contact info from any PCM or integrated contact info. (the `inactive` property was being set in the initial Add Participant Form  though but only when either a phone or email was entered, so if the user didn't enter in the contact info at that initial step, then they were having to enter it in later, in the profile, via the buggy form.)

now things work as they should:
<img width="416" alt="Screen Shot 2021-01-13 at 10 08 17 AM" src="https://user-images.githubusercontent.com/32921059/104492149-16b7f580-5588-11eb-8f76-cedb4822ea53.png">
