### PR TITLE
Task/APPS-2726 — add search participants

### DIFF
--- a/src/containers/app/AppContainer.js
+++ b/src/containers/app/AppContainer.js
@@ -40,6 +40,7 @@ import OpenLatticeLogo from '../../assets/images/logo_v2.png';
 import ParticipantProfileContainer from '../participant/ParticipantProfileContainer';
 import ParticipantsSearchContainer from '../participants/ParticipantsSearchContainer';
 import PrintWorkScheduleContainer from '../workschedule/PrintWorkScheduleContainer';
+import SearchParticipants from '../search/SearchParticipants';
 import StatsContainer from '../stats/StatsContainer';
 import WorkScheduleContainer from '../workschedule/WorkScheduleContainer';
 import WorksiteProfile from '../worksites/WorksiteProfile';
@@ -115,6 +116,7 @@ class AppContainer extends Component<Props> {
       <Route path={Routes.PRINT_WORK_SCHEDULE} component={PrintWorkScheduleContainer} />
       <Route path={Routes.WORK_SCHEDULE} component={WorkScheduleContainer} />
       <Route path={Routes.WORKSITES} component={WorksitesContainer} />
+      <Route path={Routes.SEARCH} component={SearchParticipants} />
       <Route exact strict path={Routes.ADD_PARTICIPANT} component={AddParticipantContainer} />
       <Route path={Routes.PARTICIPANT_PROFILE} component={ParticipantProfileContainer} />
       <Route path={Routes.PARTICIPANTS} component={ParticipantsSearchContainer} />
@@ -173,6 +175,7 @@ class AppContainer extends Component<Props> {
                       <NavLink to={Routes.DASHBOARD} />
                       <NavLink to={Routes.DASHBOARD}>Dashboard</NavLink>
                       <NavLink to={Routes.PARTICIPANTS}>Participants</NavLink>
+                      <NavLink to={Routes.SEARCH}>Search</NavLink>
                       <NavLink to={Routes.WORKSITES}>Work Sites</NavLink>
                       <NavLink to={Routes.WORK_SCHEDULE}>Work Schedule</NavLink>
                       <NavLink to={Routes.STATS}>Stats</NavLink>

--- a/src/containers/participants/newparticipant/SearchExistingPeople.js
+++ b/src/containers/participants/newparticipant/SearchExistingPeople.js
@@ -1,6 +1,8 @@
 // @flow
 import React, { Component } from 'react';
+
 import styled from 'styled-components';
+import { List, Map } from 'immutable';
 import {
   Button,
   Card,
@@ -9,20 +11,20 @@ import {
   DatePicker,
   Input,
   Label,
-  SearchResults,
   PaginationToolbar,
+  SearchResults,
 } from 'lattice-ui-kit';
-import { List, Map } from 'immutable';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import type { RequestSequence, RequestState } from 'redux-reqseq';
 
+import { SEARCH_EXISTING_PEOPLE, searchExistingPeople, selectExistingPerson } from './NewParticipantActions';
+
 import NoParticipantsFound from '../../dashboard/NoParticipantsFound';
-import { formatExistingPeopleData } from '../utils/NewParticipantUtils';
 import { isNonEmptyString } from '../../../utils/LangUtils';
 import { requestIsFailure, requestIsPending, requestIsSuccess } from '../../../utils/RequestStateUtils';
-import { SEARCH_EXISTING_PEOPLE, searchExistingPeople, selectExistingPerson } from './NewParticipantActions';
 import { PEOPLE, SHARED, STATE } from '../../../utils/constants/ReduxStateConsts';
+import { formatExistingPeopleData } from '../utils/NewParticipantUtils';
 
 const { PEOPLE_ALREADY_IN_ENTITY_SET } = PEOPLE;
 const { ACTIONS, REQUEST_STATE } = SHARED;
@@ -97,18 +99,17 @@ class SearchExistingPeople extends Component<Props, State> {
     this.setState({ dob: date });
   }
 
-  searchExistingPeople = (e :SyntheticEvent<HTMLInputElement> | void, startIndex :?number) => {
+  searchExistingPeople = (e :SyntheticEvent<HTMLInputElement> | void, startIndex :?number = 0) => {
     const { actions } = this.props;
     const { dob, firstName, lastName } = this.state;
 
     if (isNonEmptyString(firstName) || isNonEmptyString(lastName) || isNonEmptyString(dob)) {
-      const start = startIndex || 0;
       actions.searchExistingPeople({
         dob,
         firstName,
         lastName,
         maxHits: MAX_HITS,
-        start,
+        start: startIndex,
       });
     }
   }

--- a/src/containers/search/SearchParticipants.js
+++ b/src/containers/search/SearchParticipants.js
@@ -1,0 +1,171 @@
+// @flow
+import React, { useEffect, useState } from 'react';
+
+import styled from 'styled-components';
+import { List, Map } from 'immutable';
+import {
+  Button,
+  Card,
+  CardHeader,
+  CardSegment,
+  DatePicker,
+  Input,
+  Label,
+  PaginationToolbar,
+  SearchResults,
+  Typography,
+} from 'lattice-ui-kit';
+import {
+  DataUtils,
+  ReduxUtils,
+  useRequestState,
+} from 'lattice-utils';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { SEARCH_PARTICIPANTS, clearSearchedDataAndRequestState, searchParticipants } from './actions';
+
+import { PROPERTY_TYPE_FQNS } from '../../core/edm/constants/FullyQualifiedNames';
+import { PARTICIPANT_PROFILE } from '../../core/router/Routes';
+import { goToRoute } from '../../core/router/RoutingActions';
+import { getPersonFullName } from '../../utils/PeopleUtils';
+import { SEARCH } from '../../utils/constants/ReduxStateConsts';
+
+const { DOB } = PROPERTY_TYPE_FQNS;
+const { SEARCHED_PARTICIPANTS, TOTAL_HITS } = SEARCH;
+const { isFailure, isPending, isSuccess } = ReduxUtils;
+const { getEntityKeyId, getPropertyValue } = DataUtils;
+
+const MAX_HITS = 10;
+const resultLabels = Map({
+  name: 'Name',
+  personDOB: 'Date of Birth',
+});
+
+const SearchGrid = styled.div`
+  display: grid;
+  grid-gap: 20px;
+  grid-template-columns: repeat(4, 1fr);
+  margin-top: 20px;
+  margin-bottom: 20px;
+  width: 100%;
+
+  span:last-child {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+  }
+`;
+
+const SearchParticipants = () => {
+
+  const [formInputs, setFormInputs] = useState({ firstName: '', lastName: '' });
+  const [dob, setDOB] = useState('');
+  const [page, setPage] = useState(1);
+
+  const onInputChange = (e :SyntheticEvent<HTMLInputElement>) => {
+    const { name, value } = e.currentTarget;
+    setFormInputs({ ...formInputs, [name]: value });
+  };
+
+  const dispatch = useDispatch();
+
+  const searchCWPParticipants = (e :SyntheticEvent<HTMLInputElement> | void, startIndex :?number) => {
+    const start = startIndex || 0;
+    dispatch(searchParticipants({
+      dob,
+      firstName: formInputs.firstName,
+      lastName: formInputs.lastName,
+      maxHits: MAX_HITS,
+      start,
+    }));
+  };
+
+  const onPageChange = ({ page: newPage, start } :Object) => {
+    searchCWPParticipants(undefined, start);
+    setPage(newPage);
+  };
+
+  const searchedParticipants :List = useSelector((store) => store.getIn([SEARCH.SEARCH, SEARCHED_PARTICIPANTS]));
+  const totalHits :List = useSelector((store) => store.getIn([SEARCH.SEARCH, TOTAL_HITS]));
+
+  const data = searchedParticipants.map((searchedPerson :Map) => {
+    const name = getPersonFullName(searchedPerson);
+    const personDOB = getPropertyValue(searchedPerson, [DOB, 0]);
+    return Map({ name, id: getEntityKeyId(searchedPerson), personDOB });
+  });
+
+  const goToProfile = (clickedPerson :Map) => {
+    dispatch(goToRoute(
+      PARTICIPANT_PROFILE.replace(':participantId', clickedPerson.get('id'))
+    ));
+  };
+
+  const searchRequestState = useRequestState([SEARCH.SEARCH, SEARCH_PARTICIPANTS]);
+
+  const isSearching :boolean = isPending(searchRequestState);
+  const hasSearched :boolean = isSuccess(searchRequestState) || isFailure(searchRequestState);
+
+  useEffect(() => {
+    const resetSearchResults = () => {
+      dispatch(clearSearchedDataAndRequestState());
+    };
+    return resetSearchResults;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <>
+      <Card>
+        <CardHeader>Search CWP Participants</CardHeader>
+        <CardSegment>
+          <SearchGrid>
+            <span>
+              <Label>First name</Label>
+              <Input
+                  name="firstName"
+                  onChange={onInputChange} />
+            </span>
+            <span>
+              <Label>Last name</Label>
+              <Input
+                  name="lastName"
+                  onChange={onInputChange} />
+            </span>
+            <span>
+              <Label>Date of birth</Label>
+              <DatePicker onChange={(date :string) => setDOB(date)} />
+            </span>
+            <span>
+              <Button
+                  arialabelledby="searchParticipants"
+                  isLoading={isSearching}
+                  onClick={searchCWPParticipants}>
+                Search
+              </Button>
+            </span>
+          </SearchGrid>
+        </CardSegment>
+      </Card>
+      {
+        (hasSearched && !data.isEmpty()) && (
+          <CardSegment>
+            <Typography gutterBottom>Click on a person to visit their profile.</Typography>
+            <PaginationToolbar
+                count={totalHits}
+                onPageChange={onPageChange}
+                page={page}
+                rowsPerPage={MAX_HITS} />
+          </CardSegment>
+        )
+      }
+      <SearchResults
+          hasSearched={hasSearched}
+          isLoading={isSearching}
+          onResultClick={(clickedPerson :Map) => goToProfile(clickedPerson)}
+          resultLabels={resultLabels}
+          results={data} />
+    </>
+  );
+};
+
+export default SearchParticipants;

--- a/src/containers/search/actions/index.js
+++ b/src/containers/search/actions/index.js
@@ -1,0 +1,19 @@
+// @flow
+import { newRequestSequence } from 'redux-reqseq';
+import type { RequestSequence } from 'redux-reqseq';
+
+const CLEAR_SEARCHED_DATA_AND_REQUEST_STATE
+  :'CLEAR_SEARCHED_DATA_AND_REQUEST_STATE' = 'CLEAR_SEARCHED_DATA_AND_REQUEST_STATE';
+const clearSearchedDataAndRequestState = () => ({
+  type: CLEAR_SEARCHED_DATA_AND_REQUEST_STATE
+});
+
+const SEARCH_PARTICIPANTS :'SEARCH_PARTICIPANTS' = 'SEARCH_PARTICIPANTS';
+const searchParticipants :RequestSequence = newRequestSequence(SEARCH_PARTICIPANTS);
+
+export {
+  CLEAR_SEARCHED_DATA_AND_REQUEST_STATE,
+  SEARCH_PARTICIPANTS,
+  clearSearchedDataAndRequestState,
+  searchParticipants,
+};

--- a/src/containers/search/reducers/clearSearchedDataAndRequestStateReducer.js
+++ b/src/containers/search/reducers/clearSearchedDataAndRequestStateReducer.js
@@ -1,0 +1,19 @@
+// @flow
+
+import { List, Map } from 'immutable';
+import { ReduxConstants } from 'lattice-utils';
+import { RequestStates } from 'redux-reqseq';
+
+import { SEARCH } from '../../../utils/constants/ReduxStateConsts';
+import { SEARCH_PARTICIPANTS } from '../actions';
+
+const { SEARCHED_PARTICIPANTS, TOTAL_HITS } = SEARCH;
+
+const { REQUEST_STATE } = ReduxConstants;
+
+export default function reducer(state :Map) {
+  return state
+    .set(SEARCHED_PARTICIPANTS, List())
+    .set(TOTAL_HITS, 0)
+    .setIn([SEARCH_PARTICIPANTS, REQUEST_STATE], RequestStates.STANDBY);
+}

--- a/src/containers/search/reducers/index.js
+++ b/src/containers/search/reducers/index.js
@@ -1,0 +1,40 @@
+// @flow
+import { List, Map, fromJS } from 'immutable';
+import { ReduxConstants } from 'lattice-utils';
+import { RequestStates } from 'redux-reqseq';
+
+import clearSearchedDataAndRequestStateReducer from './clearSearchedDataAndRequestStateReducer';
+import searchParticipantsReducer from './searchParticipantsReducer';
+
+import { SEARCH } from '../../../utils/constants/ReduxStateConsts';
+import { CLEAR_SEARCHED_DATA_AND_REQUEST_STATE, SEARCH_PARTICIPANTS, searchParticipants } from '../actions';
+
+const { SEARCHED_PARTICIPANTS, TOTAL_HITS } = SEARCH;
+const { REQUEST_STATE } = ReduxConstants;
+
+const INITIAL_STATE :Map = fromJS({
+  // actions
+  [SEARCH_PARTICIPANTS]: {
+    [REQUEST_STATE]: RequestStates.STANDBY
+  },
+  // data
+  [SEARCHED_PARTICIPANTS]: List(),
+  [TOTAL_HITS]: 0,
+});
+
+export default function reducer(state :Map = INITIAL_STATE, action :Object) {
+
+  switch (action.type) {
+
+    case CLEAR_SEARCHED_DATA_AND_REQUEST_STATE: {
+      return clearSearchedDataAndRequestStateReducer(state);
+    }
+
+    case searchParticipants.case(action.type): {
+      return searchParticipantsReducer(state, action);
+    }
+
+    default:
+      return state;
+  }
+}

--- a/src/containers/search/reducers/searchParticipantsReducer.js
+++ b/src/containers/search/reducers/searchParticipantsReducer.js
@@ -1,0 +1,26 @@
+// @flow
+import { Map } from 'immutable';
+import { ReduxConstants } from 'lattice-utils';
+import { RequestStates } from 'redux-reqseq';
+import type { SequenceAction } from 'redux-reqseq';
+
+import { SEARCH } from '../../../utils/constants/ReduxStateConsts';
+import { SEARCH_PARTICIPANTS, searchParticipants } from '../actions';
+
+const { SEARCHED_PARTICIPANTS, TOTAL_HITS } = SEARCH;
+const { REQUEST_STATE } = ReduxConstants;
+
+export default function reducer(state :Map, action :SequenceAction) {
+
+  return searchParticipants.reducer(state, action, {
+    REQUEST: () => state
+      .setIn([SEARCH_PARTICIPANTS, REQUEST_STATE], RequestStates.PENDING)
+      .setIn([SEARCH_PARTICIPANTS, action.id], action),
+    SUCCESS: () => state
+      .set(SEARCHED_PARTICIPANTS, action.value.searchedParticipants)
+      .set(TOTAL_HITS, action.value.totalHits)
+      .setIn([SEARCH_PARTICIPANTS, REQUEST_STATE], RequestStates.SUCCESS),
+    FAILURE: () => state.setIn([SEARCH_PARTICIPANTS, REQUEST_STATE], RequestStates.FAILURE),
+    FINALLY: () => state.deleteIn([SEARCH_PARTICIPANTS, action.id]),
+  });
+}

--- a/src/containers/search/sagas/index.js
+++ b/src/containers/search/sagas/index.js
@@ -1,0 +1,2 @@
+// @flow
+export * from './searchParticipants';

--- a/src/containers/search/sagas/searchParticipants.js
+++ b/src/containers/search/sagas/searchParticipants.js
@@ -1,0 +1,139 @@
+// @flow
+import {
+  call,
+  put,
+  select,
+  takeEvery,
+} from '@redux-saga/core/effects';
+import { List, Map, fromJS } from 'immutable';
+import { SearchApiActions, SearchApiSagas } from 'lattice-sagas';
+import { LangUtils, Logger } from 'lattice-utils';
+import { DateTime } from 'luxon';
+import type { Saga } from '@redux-saga/core';
+import type { UUID } from 'lattice';
+import type { SequenceAction } from 'redux-reqseq';
+
+import { APP_TYPE_FQNS, PROPERTY_TYPE_FQNS } from '../../../core/edm/constants/FullyQualifiedNames';
+import {
+  getEntitySetIdFromApp,
+  getPropertyTypeIdFromEdm,
+  getSearchTerm,
+} from '../../../utils/DataUtils';
+import { STATE } from '../../../utils/constants/ReduxStateConsts';
+import { SEARCH_PARTICIPANTS, searchParticipants } from '../actions';
+
+const { isNonEmptyString } = LangUtils;
+const { searchEntitySetData } = SearchApiActions;
+const { searchEntitySetDataWorker } = SearchApiSagas;
+const { PEOPLE } = APP_TYPE_FQNS;
+const { DOB, FIRST_NAME, LAST_NAME } = PROPERTY_TYPE_FQNS;
+
+const getAppFromState = (state) => state.get(STATE.APP, Map());
+const getEdmFromState = (state) => state.get(STATE.EDM, Map());
+
+const LOG = new Logger('SearchSagas');
+
+function* searchParticipantsWorker(action :SequenceAction) :Saga<*> {
+  const { id, value } = action;
+
+  let searchedParticipants :List = List();
+  let totalHits :number = 0;
+  let response :Object = {};
+
+  try {
+    yield put(searchParticipants.request(id, value));
+    const {
+      dob,
+      firstName,
+      lastName,
+      maxHits,
+      start,
+    } = value;
+
+    const app = yield select(getAppFromState);
+    const edm = yield select(getEdmFromState);
+    const peopleESID :UUID = getEntitySetIdFromApp(app, PEOPLE);
+    const firstNamePTID :UUID = getPropertyTypeIdFromEdm(edm, FIRST_NAME);
+    const lastNamePTID :UUID = getPropertyTypeIdFromEdm(edm, LAST_NAME);
+    const dobPTID :UUID = getPropertyTypeIdFromEdm(edm, DOB);
+
+    const searchOptions = {
+      entitySetIds: [peopleESID],
+      start,
+      maxHits,
+      constraints: []
+    };
+
+    if (firstName === '*' && lastName === '*') {
+      searchOptions.constraints.push({
+        constraints: [{
+          type: 'advanced',
+          searchFields: [
+            { searchTerm: '*', property: firstNamePTID },
+            { searchTerm: '*', property: lastNamePTID }
+          ],
+        }]
+      });
+      response = yield call(searchEntitySetDataWorker, searchEntitySetData(searchOptions));
+      if (response.error) throw response.error;
+      searchedParticipants = fromJS(response.data.hits);
+      totalHits = response.data.numHits;
+    }
+    else {
+      if (isNonEmptyString(firstName)) {
+        const firstNameConstraint = getSearchTerm(firstNamePTID, firstName);
+        searchOptions.constraints.push({
+          min: 1,
+          constraints: [{
+            searchTerm: firstNameConstraint,
+            fuzzy: true
+          }]
+        });
+      }
+      if (isNonEmptyString(lastName)) {
+        const lastNameConstraint = getSearchTerm(lastNamePTID, lastName);
+        searchOptions.constraints.push({
+          min: 1,
+          constraints: [{
+            searchTerm: lastNameConstraint,
+            fuzzy: true
+          }]
+        });
+      }
+      if (DateTime.fromISO(dob).isValid) {
+        const dobConstraint = getSearchTerm(dobPTID, dob);
+        searchOptions.constraints.push({
+          min: 1,
+          constraints: [{
+            searchTerm: dobConstraint,
+            fuzzy: true
+          }]
+        });
+      }
+
+      response = yield call(searchEntitySetDataWorker, searchEntitySetData(searchOptions));
+      if (response.error) throw response.error;
+      searchedParticipants = fromJS(response.data.hits);
+      totalHits = response.data.numHits;
+    }
+
+    yield put(searchParticipants.success(id, { searchedParticipants, totalHits }));
+  }
+  catch (error) {
+    LOG.error(action.type, error);
+    yield put(searchParticipants.failure(id, error));
+  }
+  finally {
+    yield put(searchParticipants.finally(id));
+  }
+}
+
+function* searchParticipantsWatcher() :Saga<*> {
+
+  yield takeEvery(SEARCH_PARTICIPANTS, searchParticipantsWorker);
+}
+
+export {
+  searchParticipantsWatcher,
+  searchParticipantsWorker,
+};

--- a/src/core/redux/ReduxReducer.js
+++ b/src/core/redux/ReduxReducer.js
@@ -14,6 +14,7 @@ import participantReducer from '../../containers/participant/ParticipantReducer'
 import participantsReducer from '../../containers/participants/ParticipantsReducer';
 import personContactsReducer from '../../containers/participant/contacts/PersonContactsReducer';
 import printParticipantReducer from '../../containers/participant/print/PrintParticipantReducer';
+import searchReducer from '../../containers/search/reducers';
 import statsReducer from '../../containers/stats/StatsReducer';
 import workScheduleReducer from '../../containers/workschedule/WorkScheduleReducer';
 import worksitePlanReducer from '../../containers/participant/assignedworksites/WorksitePlanReducer';
@@ -32,6 +33,7 @@ export default function reduxReducer(routerHistory :any) {
     personContacts: personContactsReducer,
     printParticipant: printParticipantReducer,
     router: connectRouter(routerHistory),
+    search: searchReducer,
     stats: statsReducer,
     workSchedule: workScheduleReducer,
     worksitePlans: worksitePlanReducer,

--- a/src/core/router/Routes.js
+++ b/src/core/router/Routes.js
@@ -9,6 +9,7 @@ export const PARTICIPANTS :string = '/participants';
 export const WORKSITES :string = '/worksitesbyorganization';
 export const WORK_SCHEDULE :string = '/workschedule';
 export const STATS :string = '/stats';
+export const SEARCH :string = '/search';
 
 export const ADD_PARTICIPANT :string = `${PARTICIPANTS}/add`;
 

--- a/src/core/sagas/Sagas.js
+++ b/src/core/sagas/Sagas.js
@@ -21,6 +21,7 @@ import * as ParticipantsSagas from '../../containers/participants/ParticipantsSa
 import * as PersonContactsSagas from '../../containers/participant/contacts/PersonContactsSagas';
 import * as PrintParticipantSagas from '../../containers/participant/print/PrintParticipantSagas';
 import * as RoutingSagas from '../router/RoutingSagas';
+import * as SearchSagas from '../../containers/search/sagas';
 import * as StatsSagas from '../../containers/stats/StatsSagas';
 import * as WorkScheduleSagas from '../../containers/workschedule/WorkScheduleSagas';
 import * as WorksitePlanSagas from '../../containers/participant/assignedworksites/WorksitePlanSagas';
@@ -147,6 +148,9 @@ export default function* sagas() :Generator<*, *, *> {
 
     // PrintParticipantSagas
     fork(PrintParticipantSagas.getInfoForPrintInfractionWatcher),
+
+    // SearchSagas
+    fork(SearchSagas.searchParticipantsWatcher),
 
     // StatsSagas
     fork(StatsSagas.getStatsDataWatcher),

--- a/src/utils/constants/ReduxStateConsts.js
+++ b/src/utils/constants/ReduxStateConsts.js
@@ -184,6 +184,14 @@ export const PRINT_PARTICIPANT = {
   REQUEST_STATE: 'requestState',
 };
 
+/* Search */
+
+export const SEARCH = {
+  SEARCH: 'search',
+  SEARCHED_PARTICIPANTS: 'searchedParticipants',
+  TOTAL_HITS: 'totalHits',
+};
+
 /* Stats */
 export const STATS = {
   ACTIVE_ENROLLMENTS_BY_COURT_TYPE: 'activeEnrollmentsByCourtType',


### PR DESCRIPTION
we'd gotten away a long time without having a search people screen in CWP, but the participants table (which includes everyone + a lot of neighbors) just takes a painfully long time to load at this point, so here we go:

<img width="1405" alt="Screen Shot 2021-01-22 at 4 23 43 PM" src="https://user-images.githubusercontent.com/32921059/105562229-45437800-5cce-11eb-9b54-08c8a19c503e.png">
