### PR TITLE
Bugfix/APPS-2779 — court type missing from work schedule

### DIFF
--- a/src/containers/workschedule/WorkScheduleSagas.js
+++ b/src/containers/workschedule/WorkScheduleSagas.js
@@ -82,7 +82,7 @@ function* getPersonCourtTypeWorker(action :SequenceAction) :Generator<*, *, *> {
 
   try {
 
-    const { appointmentEKIDByWorksitePlanEKID, worksitePlanEKIDs } = value;
+    const { worksitePlanEKIDs, worksitePlanEKIDByAppointmentEKID } = value;
     const app = yield select(getAppFromState);
     const worksitePlanESID :UUID = getEntitySetIdFromApp(app, WORKSITE_PLAN);
     const diversionPlanESID :UUID = getEntitySetIdFromApp(app, DIVERSION_PLAN);
@@ -109,7 +109,6 @@ function* getPersonCourtTypeWorker(action :SequenceAction) :Generator<*, *, *> {
       diversionPlanByWorksitePlanEKID.valueSeq().toList().forEach((ekid :string) => {
         diversionPlanEKIDs.push(ekid);
       });
-      const worksitePlanEKIDByDiversionPlanEKID :Map = diversionPlanByWorksitePlanEKID.flip();
 
       const courtCasesESID :UUID = getEntitySetIdFromApp(app, MANUAL_PRETRIAL_COURT_CASES);
       searchFilter = {
@@ -129,10 +128,11 @@ function* getPersonCourtTypeWorker(action :SequenceAction) :Generator<*, *, *> {
         courtCasesByDiversionPlanEKID = courtCasesByDiversionPlanEKID
           .map((neighborList :List) => neighborList.get(0))
           .map((neighbor :Map) => getNeighborDetails(neighbor));
-        courtCasesByDiversionPlanEKID.forEach((courtCase :Map, diversionPlanEKID :UUID) => {
+
+        worksitePlanEKIDByAppointmentEKID.forEach((worksitePlanEKID, appointmentEKID) => {
+          const diversionPlanEKID = diversionPlanByWorksitePlanEKID.get(worksitePlanEKID, '');
+          const courtCase = courtCasesByDiversionPlanEKID.get(diversionPlanEKID, '');
           const { [COURT_CASE_TYPE]: courtType } = getEntityProperties(courtCase, [COURT_CASE_TYPE]);
-          const worksitePlanEKID :UUID = worksitePlanEKIDByDiversionPlanEKID.get(diversionPlanEKID, '');
-          const appointmentEKID :UUID = appointmentEKIDByWorksitePlanEKID.get(worksitePlanEKID, '');
           courtTypeByAppointmentEKID = courtTypeByAppointmentEKID.set(appointmentEKID, courtType);
         });
       }

--- a/src/containers/workschedule/WorkScheduleSagas.js
+++ b/src/containers/workschedule/WorkScheduleSagas.js
@@ -285,18 +285,16 @@ function* getWorksiteAndPersonNamesWorker(action :SequenceAction) :Generator<*, 
     }
     const worksitePlans :Map = fromJS(response.data);
     const setOfWorksitePlanEKIDs :Set<*> = new Set();
-    let appointmentWorksitePlanEKIDMap :Map = Map();
+    let worksitePlanEKIDByAppointmentEKID :Map = Map();
 
     worksitePlans.forEach((worksitePlanList :List, appointmentEKID :UUID) => {
       const worksitePlan :Map = getNeighborDetails(worksitePlanList.get(0));
       const worksitePlanEKID :UUID = getEntityKeyId(worksitePlan);
       setOfWorksitePlanEKIDs.add(worksitePlanEKID);
-      appointmentWorksitePlanEKIDMap = appointmentWorksitePlanEKIDMap.set(appointmentEKID, worksitePlanEKID);
+      worksitePlanEKIDByAppointmentEKID = worksitePlanEKIDByAppointmentEKID.set(appointmentEKID, worksitePlanEKID);
     });
     const worksitePlanEKIDs :UUID[] = Array.from(setOfWorksitePlanEKIDs);
-
-    const appointmentEKIDByWorksitePlanEKID :Map = appointmentWorksitePlanEKIDMap.flip();
-    yield call(getPersonCourtTypeWorker, getPersonCourtType({ appointmentEKIDByWorksitePlanEKID, worksitePlanEKIDs }));
+    yield call(getPersonCourtTypeWorker, getPersonCourtType({ worksitePlanEKIDs, worksitePlanEKIDByAppointmentEKID }));
 
     const worksiteESID :UUID = getEntitySetIdFromApp(app, WORKSITE);
     const peopleESID :UUID = getEntitySetIdFromApp(app, PEOPLE);
@@ -332,7 +330,7 @@ function* getWorksiteAndPersonNamesWorker(action :SequenceAction) :Generator<*, 
 
     yield call(getWorksitePlansByPersonWorker, getWorksitePlansByPerson({ personEKIDs }));
 
-    appointmentWorksitePlanEKIDMap.forEach((worksitePlanEKID :UUID, appointmentEKID :UUID) => {
+    worksitePlanEKIDByAppointmentEKID.forEach((worksitePlanEKID :UUID, appointmentEKID :UUID) => {
       const worksite :Map = worksitesByWorksitePlan.get(worksitePlanEKID);
       const { [NAME]: worksiteName } = getEntityProperties(worksite, [NAME]);
       worksiteNamesByAppointmentEKID = worksiteNamesByAppointmentEKID.set(appointmentEKID, worksiteName);


### PR DESCRIPTION
In the `WorkSchedule`, some work appointments did not have their "Court Type" defined, despite the property type existing on the court case entity. This was because of a bug in creating a map of `worksite plan : appointment`—there can be multiple appointments for the same worksite plan on the screen at a time, but this map was creating a 1:1 relationship between worksite plan and appointment, which meant later on creating a `appointment : court type` map would be leaving out some appointments.