### PR TITLE
Task/APPS-2837 — "became active" status in enrollments by court type graph

### DIFF
--- a/src/containers/stats/StatsContainer.js
+++ b/src/containers/stats/StatsContainer.js
@@ -54,6 +54,7 @@ const {
 } = Colors;
 const {
   ACTIVE_ENROLLMENTS_BY_COURT_TYPE,
+  BECAME_ACTIVE_ENROLLMENTS_BY_COURT_TYPE,
   CLOSED_ENROLLMENTS_BY_COURT_TYPE,
   JOB_SEARCH_ENROLLMENTS_BY_COURT_TYPE,
   SUCCESSFUL_ENROLLMENTS_BY_COURT_TYPE,
@@ -186,6 +187,7 @@ type Props = {
     getWorksiteStatsData :RequestSequence;
   };
   activeEnrollmentsByCourtType :Map;
+  becameActiveEnrollmentsByCourtType :Map;
   closedEnrollmentsByCourtType :Map;
   entitySetIds :Map;
   jobSearchEnrollmentsByCourtType :Map;
@@ -208,6 +210,7 @@ type Props = {
 const StatsContainer = ({
   actions,
   activeEnrollmentsByCourtType,
+  becameActiveEnrollmentsByCourtType,
   closedEnrollmentsByCourtType,
   entitySetIds,
   jobSearchEnrollmentsByCourtType,
@@ -239,6 +242,7 @@ const StatsContainer = ({
   const courtTypeGraphsComponent = (
     <CourtTypeGraphs
         activeEnrollmentsByCourtType={activeEnrollmentsByCourtType}
+        becameActiveEnrollmentsByCourtType={becameActiveEnrollmentsByCourtType}
         closedEnrollmentsByCourtType={closedEnrollmentsByCourtType}
         dataIsLoading={dataIsLoading}
         jobSearchEnrollmentsByCourtType={jobSearchEnrollmentsByCourtType}
@@ -369,6 +373,7 @@ const mapStateToProps = (state :Map) => {
   const selectedOrgId :string = app.get(SELECTED_ORG_ID);
   return {
     [ACTIVE_ENROLLMENTS_BY_COURT_TYPE]: stats.get(ACTIVE_ENROLLMENTS_BY_COURT_TYPE),
+    [BECAME_ACTIVE_ENROLLMENTS_BY_COURT_TYPE]: stats.get(BECAME_ACTIVE_ENROLLMENTS_BY_COURT_TYPE),
     [CLOSED_ENROLLMENTS_BY_COURT_TYPE]: stats.get(CLOSED_ENROLLMENTS_BY_COURT_TYPE),
     [JOB_SEARCH_ENROLLMENTS_BY_COURT_TYPE]: stats.get(JOB_SEARCH_ENROLLMENTS_BY_COURT_TYPE),
     [SUCCESSFUL_ENROLLMENTS_BY_COURT_TYPE]: stats.get(SUCCESSFUL_ENROLLMENTS_BY_COURT_TYPE),

--- a/src/containers/stats/StatsReducer.js
+++ b/src/containers/stats/StatsReducer.js
@@ -5,6 +5,14 @@ import type { SequenceAction } from 'redux-reqseq';
 
 import { GET_STATS_DATA, getStatsData } from './StatsActions';
 import {
+  DOWNLOAD_CHARGES_STATS,
+  GET_CHARGES_STATS,
+  GET_INDIVIDUAL_CHARGE_TYPE_STATS,
+  downloadChargesStats,
+  getChargesStats,
+  getIndividualChargeTypeStats,
+} from './charges/ChargesStatsActions';
+import {
   DOWNLOAD_COURT_TYPE_DATA,
   GET_ENROLLMENTS_BY_COURT_TYPE,
   GET_HOURS_BY_COURT_TYPE,
@@ -17,6 +25,14 @@ import {
   getTotalParticipantsByCourtType,
 } from './courttype/CourtTypeActions';
 import {
+  DOWNLOAD_DEMOGRAPHICS_DATA,
+  GET_MONTHLY_DEMOGRAPHICS,
+  GET_PARTICIPANTS_DEMOGRAPHICS,
+  downloadDemographicsData,
+  getMonthlyDemographics,
+  getParticipantsDemographics,
+} from './demographics/DemographicsActions';
+import {
   DOWNLOAD_WORKSITE_STATS_DATA,
   GET_HOURS_WORKED_BY_WORKSITE,
   GET_MONTHLY_PARTICIPANTS_BY_WORKSITE,
@@ -26,28 +42,14 @@ import {
   getMonthlyParticipantsByWorksite,
   getWorksiteStatsData,
 } from './worksite/WorksiteStatsActions';
-import {
-  DOWNLOAD_DEMOGRAPHICS_DATA,
-  GET_MONTHLY_DEMOGRAPHICS,
-  GET_PARTICIPANTS_DEMOGRAPHICS,
-  downloadDemographicsData,
-  getMonthlyDemographics,
-  getParticipantsDemographics,
-} from './demographics/DemographicsActions';
-import {
-  DOWNLOAD_CHARGES_STATS,
-  GET_CHARGES_STATS,
-  GET_INDIVIDUAL_CHARGE_TYPE_STATS,
-  downloadChargesStats,
-  getChargesStats,
-  getIndividualChargeTypeStats,
-} from './charges/ChargesStatsActions';
+
 import { SHARED, STATS } from '../../utils/constants/ReduxStateConsts';
 
 const { ACTIONS, REQUEST_STATE } = SHARED;
 const {
   ACTIVE_ENROLLMENTS_BY_COURT_TYPE,
   ARREST_CHARGE_TABLE_DATA,
+  BECAME_ACTIVE_ENROLLMENTS_BY_COURT_TYPE,
   CLOSED_ENROLLMENTS_BY_COURT_TYPE,
   COURT_CHARGE_TABLE_DATA,
   ETHNICITY_DEMOGRAPHICS,
@@ -122,6 +124,7 @@ const INITIAL_STATE :Map<*, *> = fromJS({
   },
   [ACTIVE_ENROLLMENTS_BY_COURT_TYPE]: Map(),
   [ARREST_CHARGE_TABLE_DATA]: List(),
+  [BECAME_ACTIVE_ENROLLMENTS_BY_COURT_TYPE]: Map(),
   [CLOSED_ENROLLMENTS_BY_COURT_TYPE]: Map(),
   [COURT_CHARGE_TABLE_DATA]: List(),
   [HOURS_BY_COURT_TYPE]: Map(),
@@ -217,6 +220,7 @@ export default function statsReducer(state :Map<*, *> = INITIAL_STATE, action :O
           const { value } = seqAction;
           const {
             activeEnrollmentsByCourtType,
+            becameActiveEnrollmentsByCourtType,
             closedEnrollmentsByCourtType,
             jobSearchEnrollmentsByCourtType,
             successfulEnrollmentsByCourtType,
@@ -224,6 +228,7 @@ export default function statsReducer(state :Map<*, *> = INITIAL_STATE, action :O
           } = value;
           return state
             .set(ACTIVE_ENROLLMENTS_BY_COURT_TYPE, activeEnrollmentsByCourtType)
+            .set(BECAME_ACTIVE_ENROLLMENTS_BY_COURT_TYPE, becameActiveEnrollmentsByCourtType)
             .set(CLOSED_ENROLLMENTS_BY_COURT_TYPE, closedEnrollmentsByCourtType)
             .set(JOB_SEARCH_ENROLLMENTS_BY_COURT_TYPE, jobSearchEnrollmentsByCourtType)
             .set(SUCCESSFUL_ENROLLMENTS_BY_COURT_TYPE, successfulEnrollmentsByCourtType)

--- a/src/containers/stats/courttype/CourtTypeGraphs.js
+++ b/src/containers/stats/courttype/CourtTypeGraphs.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+
 import { Map } from 'immutable';
 import { CardStack } from 'lattice-ui-kit';
 
@@ -10,6 +11,7 @@ import ParticipantsByCourtType from './ParticipantsByCourtType';
 
 type Props = {
   activeEnrollmentsByCourtType :Map;
+  becameActiveEnrollmentsByCourtType :Map,
   closedEnrollmentsByCourtType :Map;
   jobSearchEnrollmentsByCourtType :Map;
   successfulEnrollmentsByCourtType :Map;
@@ -18,6 +20,7 @@ type Props = {
 
 const CourtTypeGraphs = ({
   activeEnrollmentsByCourtType,
+  becameActiveEnrollmentsByCourtType,
   closedEnrollmentsByCourtType,
   jobSearchEnrollmentsByCourtType,
   successfulEnrollmentsByCourtType,
@@ -27,6 +30,7 @@ const CourtTypeGraphs = ({
   <CardStack>
     <EnrollmentsAndStatusByCourtType
         activeEnrollmentsByCourtType={activeEnrollmentsByCourtType}
+        becameActiveEnrollmentsByCourtType={becameActiveEnrollmentsByCourtType}
         closedEnrollmentsByCourtType={closedEnrollmentsByCourtType}
         jobSearchEnrollmentsByCourtType={jobSearchEnrollmentsByCourtType}
         successfulEnrollmentsByCourtType={successfulEnrollmentsByCourtType}

--- a/src/containers/stats/courttype/EnrollmentsAndStatusByCourtType.js
+++ b/src/containers/stats/courttype/EnrollmentsAndStatusByCourtType.js
@@ -112,6 +112,7 @@ type Props = {
     getStatsData :RequestSequence;
   };
   activeEnrollmentsByCourtType :Map;
+  becameActiveEnrollmentsByCourtType :Map,
   closedEnrollmentsByCourtType :Map;
   jobSearchEnrollmentsByCourtType :Map;
   requestStates :{
@@ -127,6 +128,7 @@ type Props = {
 const EnrollmentsAndStatusByCourtType = ({
   actions,
   activeEnrollmentsByCourtType,
+  becameActiveEnrollmentsByCourtType,
   closedEnrollmentsByCourtType,
   jobSearchEnrollmentsByCourtType,
   requestStates,
@@ -193,19 +195,25 @@ const EnrollmentsAndStatusByCourtType = ({
     const courtType :string = v.y;
     if (!isDefined(courtType)) return [];
     const active = activeEnrollmentsByCourtType.get(courtType, 0);
+    const becameActive = becameActiveEnrollmentsByCourtType.get(courtType, 0);
     const closed = closedEnrollmentsByCourtType.get(courtType, 0);
     const jobSearch = jobSearchEnrollmentsByCourtType.get(courtType, 0);
     const successful = successfulEnrollmentsByCourtType.get(courtType, 0);
     const unsuccessful = unsuccessfulEnrollmentsByCourtType.get(courtType, 0);
-    return [
+    const statusCounts = [
       { title: courtType, value: '' },
       { title: 'successful', value: successful },
       { title: 'unsuccessful', value: unsuccessful },
       { title: 'closed', value: closed },
       { title: 'active', value: active },
+      { title: '[became active]', value: becameActive },
       { title: 'job search', value: jobSearch },
       { title: 'total', value: active + closed + jobSearch + successful + unsuccessful },
     ];
+    if (timeFrame.value === ALL_TIME) {
+      statusCounts.splice(5, 1);
+    }
+    return statusCounts;
   };
   return (
     <Card>

--- a/src/utils/constants/ReduxStateConsts.js
+++ b/src/utils/constants/ReduxStateConsts.js
@@ -196,6 +196,7 @@ export const SEARCH = {
 export const STATS = {
   ACTIVE_ENROLLMENTS_BY_COURT_TYPE: 'activeEnrollmentsByCourtType',
   ARREST_CHARGE_TABLE_DATA: 'arrestChargeTableData',
+  BECAME_ACTIVE_ENROLLMENTS_BY_COURT_TYPE: 'becameActiveEnrollmentsByCourtType',
   CLOSED_ENROLLMENTS_BY_COURT_TYPE: 'closedEnrollmentsByCourtType',
   COURT_CHARGE_TABLE_DATA: 'courtChargeTableData',
   ETHNICITY_DEMOGRAPHICS: 'ethnicityDemographics',


### PR DESCRIPTION
Users want to know how many enrollments they marked as 'active' within a given month or year. There's already subsection of each bar on the graph and a designator in the tooltip for all active enrollments, but I added a '[became active]' designator to the tooltip to show how many of those active enrollments actually became active during the time frame. The '[became active]' total does not appear as a subsection on the bar itself and it does not contribute to the total number of enrollments for the bar (or on the tooltip).

<img width="1082" alt="Screen Shot 2021-03-24 at 1 49 57 PM" src="https://user-images.githubusercontent.com/32921059/112381543-ee472880-8ca7-11eb-9f18-2b0ef5b5e9f4.png">
