### PR TITLE
Bugfix/APPS-2832 — program notes disappear

### DIFF
--- a/src/containers/participant/notes/EditPersonNotesForm.js
+++ b/src/containers/participant/notes/EditPersonNotesForm.js
@@ -58,8 +58,9 @@ class EditPlanNotesForm extends Component<Props, State> {
   constructor(props :Props) {
     super(props);
 
+    const { [PERSON_NOTES]: notes } = getEntityProperties(props.person, [PERSON_NOTES]);
     this.state = {
-      newNotes: '',
+      newNotes: notes,
     };
   }
 

--- a/src/containers/participant/notes/EditPlanNotesForm.js
+++ b/src/containers/participant/notes/EditPlanNotesForm.js
@@ -58,8 +58,10 @@ class EditPlanNotesForm extends Component<Props, State> {
   constructor(props :Props) {
     super(props);
 
+    const { [NOTES]: notes } = getEntityProperties(props.diversionPlan, [NOTES]);
+
     this.state = {
-      newNotes: '',
+      newNotes: notes,
     };
   }
 


### PR DESCRIPTION
if you opened this modal to view already existing notes, and then click "Submit" (but not update anything before clicking submit), they would seem to "disappear". this is because in the form's state, the default was an empty string instead of the existing notes... and even though the textarea default was set to the existing notes, the form was submitting the empty string from state as the new notes.

fixed that:

![d3e23f6515754644ad6dd8094ae6f42a](https://user-images.githubusercontent.com/32921059/112697929-cf7e9880-8e45-11eb-8790-2ddeec386f5f.gif)
