### PR TITLE
Task/APPS-2836 - fix participants hours list

### DIFF
--- a/src/containers/stats/courttype/CourtTypeSagas.js
+++ b/src/containers/stats/courttype/CourtTypeSagas.js
@@ -913,6 +913,10 @@ function* getMonthlyParticipantsByCourtTypeWorker(action :SequenceAction) :Gener
 
       monthlyParticipantsByCourtType = monthlyParticipantsWithNoCheckInsByCourtType
         .mergeDeepWith((oldVal, newVal) => oldVal + newVal, monthlyParticipantsByCourtType);
+
+      monthlyParticipantsByCourtType = monthlyParticipantsByCourtType
+        .map((courtTypeMap :Map) => courtTypeMap.keySeq().toList()
+          .map((personName :string) => fromJS({ personName, hours: courtTypeMap.get(personName) })));
     }
 
     monthlyParticipantsByCourtType = monthlyParticipantsByCourtType.asImmutable();

--- a/src/containers/stats/courttype/CourtTypeSagas.js
+++ b/src/containers/stats/courttype/CourtTypeSagas.js
@@ -102,13 +102,10 @@ const updateMonthlyParticipantMap = (
   const courtCase = courtCaseByDiversionPlanEKID.get(diversionPlanEKID, Map());
   const { [COURT_CASE_TYPE]: courtType } = getEntityProperties(courtCase, [COURT_CASE_TYPE]);
   if (isDefined(updatedMap.get(courtType))) {
-    let listOfParticipantsAndTheirHours :List = updatedMap
-      .get(courtType, List());
-    if (!listOfParticipantsAndTheirHours.find((participantMap :Map) => participantMap
-      .get('personName') === personName)) {
-      listOfParticipantsAndTheirHours = listOfParticipantsAndTheirHours.push(fromJS({ personName, hours: 0 }));
-    }
-    updatedMap = updatedMap.set(courtType, listOfParticipantsAndTheirHours);
+    let participantsAndTheirHoursByCourtType :Map = updatedMap.get(courtType, Map());
+    const participantHours = participantsAndTheirHoursByCourtType.get(personName, 0);
+    participantsAndTheirHoursByCourtType = participantsAndTheirHoursByCourtType.set(personName, participantHours);
+    updatedMap = updatedMap.set(courtType, participantsAndTheirHoursByCourtType);
   }
   return updatedMap;
 };

--- a/src/containers/stats/courttype/CourtTypeSagas.js
+++ b/src/containers/stats/courttype/CourtTypeSagas.js
@@ -910,8 +910,9 @@ function* getMonthlyParticipantsByCourtTypeWorker(action :SequenceAction) :Gener
       );
       if (response.error) throw response.error;
       const monthlyParticipantsWithNoCheckInsByCourtType :Map = response.data;
+
       monthlyParticipantsByCourtType = monthlyParticipantsWithNoCheckInsByCourtType
-        .mergeDeep(monthlyParticipantsByCourtType);
+        .mergeDeepWith((oldVal, newVal) => oldVal + newVal, monthlyParticipantsByCourtType);
     }
 
     monthlyParticipantsByCourtType = monthlyParticipantsByCourtType.asImmutable();

--- a/src/containers/stats/courttype/CourtTypeSagas.js
+++ b/src/containers/stats/courttype/CourtTypeSagas.js
@@ -915,8 +915,12 @@ function* getMonthlyParticipantsByCourtTypeWorker(action :SequenceAction) :Gener
         .mergeDeepWith((oldVal, newVal) => oldVal + newVal, monthlyParticipantsByCourtType);
 
       monthlyParticipantsByCourtType = monthlyParticipantsByCourtType
-        .map((courtTypeMap :Map) => courtTypeMap.keySeq().toList()
-          .map((personName :string) => fromJS({ personName, hours: courtTypeMap.get(personName) })));
+        .map((courtTypeMap :Map) => (
+          courtTypeMap
+            .keySeq()
+            .toList()
+            .map((personName :string) => fromJS({ personName, hours: courtTypeMap.get(personName) }))
+        ));
     }
 
     monthlyParticipantsByCourtType = monthlyParticipantsByCourtType.asImmutable();

--- a/src/containers/stats/courttype/CourtTypeSagas.js
+++ b/src/containers/stats/courttype/CourtTypeSagas.js
@@ -889,17 +889,17 @@ function* getMonthlyParticipantsByCourtTypeWorker(action :SequenceAction) :Gener
           const hours :number = hoursByCheckInEKID.get(checkInEKID, 0);
 
           if (isDefined(monthlyParticipantsByCourtType.get(courtType))) {
-            let participantsAndTheirHoursByCourtType :Map = monthlyParticipantsByCourtType.get(courtType, Map());
-            if (!isDefined(participantsAndTheirHoursByCourtType.get(personName))) {
-              participantsAndTheirHoursByCourtType = participantsAndTheirHoursByCourtType.set(personName, hours);
+            let hoursByParticipantName :Map = monthlyParticipantsByCourtType.get(courtType, Map());
+            if (!isDefined(hoursByParticipantName.get(personName))) {
+              hoursByParticipantName = hoursByParticipantName.set(personName, hours);
             }
             else {
-              const currentHours = participantsAndTheirHoursByCourtType.get(personName);
-              participantsAndTheirHoursByCourtType = participantsAndTheirHoursByCourtType
+              const currentHours = hoursByParticipantName.get(personName);
+              hoursByParticipantName = hoursByParticipantName
                 .set(personName, currentHours + hours);
             }
             monthlyParticipantsByCourtType = monthlyParticipantsByCourtType
-              .set(courtType, participantsAndTheirHoursByCourtType);
+              .set(courtType, hoursByParticipantName);
           }
         });
       });

--- a/src/containers/stats/courttype/CourtTypeSagas.js
+++ b/src/containers/stats/courttype/CourtTypeSagas.js
@@ -887,23 +887,19 @@ function* getMonthlyParticipantsByCourtTypeWorker(action :SequenceAction) :Gener
           const courtType :string = courtTypesByDiversionPlanEKIDs.get(diversionPlanEKID, '');
           const personName :string = personNameByPersonEKID.get(personEKID, '');
           const hours :number = hoursByCheckInEKID.get(checkInEKID, 0);
+
           if (isDefined(monthlyParticipantsByCourtType.get(courtType))) {
-            let listOfParticipantsAndTheirHours :List = monthlyParticipantsByCourtType.get(courtType, List());
-            if (!listOfParticipantsAndTheirHours
-              .find((participantMap :Map) => participantMap.get('personName') === personName)) {
-              listOfParticipantsAndTheirHours = listOfParticipantsAndTheirHours.push(fromJS({ personName, hours }));
+            let participantsAndTheirHoursByCourtType :Map = monthlyParticipantsByCourtType.get(courtType, Map());
+            if (!isDefined(participantsAndTheirHoursByCourtType.get(personName))) {
+              participantsAndTheirHoursByCourtType = participantsAndTheirHoursByCourtType.set(personName, hours);
             }
             else {
-              const participantIndex :number = listOfParticipantsAndTheirHours
-                .findIndex((participantMap :Map) => participantMap.get('personName') === personName);
-              listOfParticipantsAndTheirHours = listOfParticipantsAndTheirHours
-                .setIn(
-                  [participantIndex, 'hours'],
-                  listOfParticipantsAndTheirHours.getIn([participantIndex, 'hours']) + hours
-                );
+              const currentHours = participantsAndTheirHoursByCourtType.get(personName);
+              participantsAndTheirHoursByCourtType = participantsAndTheirHoursByCourtType
+                .set(personName, currentHours + hours);
             }
             monthlyParticipantsByCourtType = monthlyParticipantsByCourtType
-              .set(courtType, listOfParticipantsAndTheirHours);
+              .set(courtType, participantsAndTheirHoursByCourtType);
           }
         });
       });

--- a/src/containers/stats/courttype/CourtTypeSagas.js
+++ b/src/containers/stats/courttype/CourtTypeSagas.js
@@ -531,7 +531,7 @@ function* getMonthlyParticipantsWithNoCheckInsWorker(action :SequenceAction) :Ge
   const { id, value } = action;
   let monthlyParticipantsWithNoCheckInsByCourtType :Map = fromJS(courtTypeCountObj)
     .asMutable()
-    .map(() => List());
+    .map(() => Map());
   let workerResponse :WorkerResponse = { data: {} };
 
   try {
@@ -733,7 +733,7 @@ function* getMonthlyParticipantsByCourtTypeWorker(action :SequenceAction) :Gener
   if (!isDefined(value)) throw ERR_ACTION_VALUE_NOT_DEFINED;
   let monthlyParticipantsByCourtType :Map = fromJS(courtTypeCountObj)
     .asMutable()
-    .map(() => List());
+    .map(() => Map());
 
   try {
     yield put(getMonthlyParticipantsByCourtType.request(id));


### PR DESCRIPTION
the process for getting this monthly list of participants & hours by court type involves getting 1) check-ins (which store hours) + a bunch of neighbors, and 2) diversion plans that were active that month but have 0 completed hours (thus no check-ins). before the saga finishes, the two maps are merged. however, i was deeply merging maps with lists of things, but i should've been merging nested maps, so that a person was not counted twice in the list if they appeared in both map 1 and map 2...which i guess happens a lot, and i noticed that on staging. now, if John Doe was enrolled in March and did 0 hours but then was enrolled again later in the month and did 8 hours, the list item will just be "John Doe • 8 hours", instead of there being two John Does, one with 8 and one with 0. 