### PR TITLE
bugfix/APPS-2857 — fix Add Participant Form for arrest charges

### DIFF
--- a/src/containers/participants/newparticipant/AddParticipantForm.js
+++ b/src/containers/participants/newparticipant/AddParticipantForm.js
@@ -346,7 +346,7 @@ class AddParticipantForm extends Component<Props, State> {
     const { newChargeEntities, newChargeAssociations } = formatNewArrestChargeDataAndAssociations(
       charges,
       0,
-      { personIndexOrEKID: 0, diversionPlanIndexOrEKID: 0 }
+      { personIndexOrEKID, diversionPlanIndexOrEKID: 0 }
     );
     dataToSubmit[getPageSectionKey(1, 4)] = newChargeEntities;
     associations = associations.concat(newChargeAssociations);


### PR DESCRIPTION
associations are using index 0 in Add Participant Form for arrest charges when they should be using whatever was set to the `personIndexOrEKID` variable, which is either 0 or an existing person EKID. 