### PR TITLE
Task/APPS-2877 — refine worksite hours worked calculation

### DIFF
--- a/src/containers/participant/assignedworksites/EditWorksitePlanForm.js
+++ b/src/containers/participant/assignedworksites/EditWorksitePlanForm.js
@@ -43,12 +43,7 @@ const {
   RELATED_TO,
   WORKSITE_PLAN,
 } = APP_TYPE_FQNS;
-const {
-  EFFECTIVE_DATE,
-  HOURS_WORKED,
-  REQUIRED_HOURS,
-  STATUS,
-} = PROPERTY_TYPE_FQNS;
+const { EFFECTIVE_DATE, REQUIRED_HOURS, STATUS } = PROPERTY_TYPE_FQNS;
 const { ENTITY_SET_IDS_BY_ORG, SELECTED_ORG_ID } = APP;
 const { PROPERTY_TYPES, TYPE_IDS_BY_FQNS } = EDM;
 
@@ -68,7 +63,6 @@ type Props = {
 };
 
 type State = {
-  hoursWorked :number | null;
   newStatus :string;
   requiredHours :number | null;
 };
@@ -78,7 +72,6 @@ class EditWorksitePlanForm extends Component<Props, State> {
   constructor(props :Props) {
     super(props);
     this.state = {
-      hoursWorked: null,
       newStatus: '',
       requiredHours: null,
     };
@@ -102,13 +95,12 @@ class EditWorksitePlanForm extends Component<Props, State> {
       propertyTypeIds,
       worksitePlan,
     } = this.props;
-    const { hoursWorked, newStatus, requiredHours } = this.state;
+    const { newStatus, requiredHours } = this.state;
 
     const worksitePlanEKID :UUID = getEntityKeyId(worksitePlan);
     const nowAsIso = DateTime.local().toISO();
 
     const worksitePlanESID :UUID = entitySetIds.get(WORKSITE_PLAN);
-    const hoursWorkedPTID :UUID = propertyTypeIds.get(HOURS_WORKED);
     const requiredHoursPTID :UUID = propertyTypeIds.get(REQUIRED_HOURS);
 
     let statusEntityData :{} = {};
@@ -119,9 +111,6 @@ class EditWorksitePlanForm extends Component<Props, State> {
       }
     };
 
-    if (isDefined(hoursWorked)) {
-      worksitePlanDataToEdit[worksitePlanESID][worksitePlanEKID][hoursWorkedPTID] = [hoursWorked];
-    }
     if (isDefined(requiredHours)) {
       worksitePlanDataToEdit[worksitePlanESID][worksitePlanEKID][requiredHoursPTID] = [requiredHours];
     }
@@ -160,22 +149,9 @@ class EditWorksitePlanForm extends Component<Props, State> {
       worksitePlan,
       worksitePlanStatus
     } = this.props;
-    const {
-      [HOURS_WORKED]: hoursWorked,
-      [REQUIRED_HOURS]: requiredHours
-    } = getEntityProperties(worksitePlan, [HOURS_WORKED, REQUIRED_HOURS]);
+    const { [REQUIRED_HOURS]: requiredHours } = getEntityProperties(worksitePlan, [REQUIRED_HOURS]);
     return (
       <FormWrapper>
-        <FormRow>
-          <RowContent>
-            <Label>Hours worked at site</Label>
-            <Input
-                defaultValue={hoursWorked}
-                name="hoursWorked"
-                onChange={this.handleInputChange}
-                type="text" />
-          </RowContent>
-        </FormRow>
         <FormRow>
           <RowContent>
             <Label>Required hours at site</Label>

--- a/src/containers/participant/assignedworksites/WorksitePlanReducer.js
+++ b/src/containers/participant/assignedworksites/WorksitePlanReducer.js
@@ -57,6 +57,7 @@ const {
   UPDATE_HOURS_WORKED,
   WORKSITES_BY_WORKSITE_PLAN,
   WORKSITE_PLANS_LIST,
+  WORKSITE_PLAN_EKID_BY_APPOINTMENT_EKID,
   WORKSITE_PLAN_STATUSES,
   WORK_APPOINTMENTS_BY_WORKSITE_PLAN,
 } = WORKSITE_PLANS;
@@ -112,6 +113,7 @@ const INITIAL_STATE :Map<*, *> = fromJS({
   [CHECK_INS_BY_APPOINTMENT]: Map(),
   [WORKSITES_BY_WORKSITE_PLAN]: Map(),
   [WORKSITE_PLANS_LIST]: List(),
+  [WORKSITE_PLAN_EKID_BY_APPOINTMENT_EKID]: Map(),
   [WORKSITE_PLAN_STATUSES]: Map(),
   [WORK_APPOINTMENTS_BY_WORKSITE_PLAN]: Map(),
 });
@@ -559,18 +561,10 @@ export default function worksitePlanReducer(state :Map<*, *> = INITIAL_STATE, ac
           .setIn([ACTIONS, GET_WORK_APPOINTMENTS, action.id], fromJS(action))
           .setIn([ACTIONS, GET_WORK_APPOINTMENTS, REQUEST_STATE], RequestStates.PENDING),
         SUCCESS: () => {
-
-          if (!state.hasIn([ACTIONS, GET_WORK_APPOINTMENTS, action.id])) {
-            return state;
-          }
-
-          const { value } = action;
-          if (value === null || value === undefined) {
-            return state;
-          }
-
+          const { workAppointmentsByWorksitePlan, worksitePlanEKIDByAppointmentEKID } = action.value;
           return state
-            .set(WORK_APPOINTMENTS_BY_WORKSITE_PLAN, value)
+            .set(WORK_APPOINTMENTS_BY_WORKSITE_PLAN, workAppointmentsByWorksitePlan)
+            .set(WORKSITE_PLAN_EKID_BY_APPOINTMENT_EKID, worksitePlanEKIDByAppointmentEKID)
             .setIn([ACTIONS, GET_WORK_APPOINTMENTS, REQUEST_STATE], RequestStates.SUCCESS);
         },
         FAILURE: () => state

--- a/src/containers/participant/assignedworksites/WorksitePlanSagas.js
+++ b/src/containers/participant/assignedworksites/WorksitePlanSagas.js
@@ -972,13 +972,12 @@ function* checkInForAppointmentWorker(action :SequenceAction) :Generator<*, *, *
       const checkInDetailsESID :UUID = getEntitySetIdFromApp(app, CHECK_IN_DETAILS);
       const hoursWorkedPTID :UUID = getPropertyTypeIdFromEdm(edm, HOURS_WORKED);
       const { entityData } = value;
-      const numberHoursWorked :number = entityData[checkInDetailsESID][0][hoursWorkedPTID][0];
 
       const { associationEntityData } = value;
       const fulfillsESID :UUID = getEntitySetIdFromApp(app, FULFILLS);
       const appointmentEKID :UUID = associationEntityData[fulfillsESID][0].dstEntityKeyId;
 
-      response = yield call(updateHoursWorkedWorker, updateHoursWorked({ appointmentEKID, numberHoursWorked }));
+      response = yield call(updateHoursWorkedWorker, updateHoursWorked({ appointmentEKID }));
       if (response.error) throw response.error;
 
       const storedCheckInEntity :Map = fromJS(entityData[checkInESID][0]);
@@ -1027,12 +1026,12 @@ function* deleteCheckInWorker(action :SequenceAction) :Generator<*, *, *> {
   try {
     yield put(deleteCheckIn.request(id, value));
 
-    const { appointmentEKID, checkInToDelete, numberHoursWorked } = value;
+    const { appointmentEKID, checkInToDelete, worksitePlanEKID } = value;
 
     let response :Object = yield call(deleteEntitiesWorker, deleteEntities(checkInToDelete));
     if (response.error) throw response.error;
 
-    response = yield call(updateHoursWorkedWorker, updateHoursWorked({ appointmentEKID, numberHoursWorked }));
+    response = yield call(updateHoursWorkedWorker, updateHoursWorked({ appointmentEKID, worksitePlanEKID }));
     if (response.error) throw response.error;
 
     yield put(deleteCheckIn.success(id));

--- a/src/containers/participant/schedule/CheckInDetailsModal.js
+++ b/src/containers/participant/schedule/CheckInDetailsModal.js
@@ -80,6 +80,7 @@ type Props = {
   checkIn :Map;
   isOpen :boolean;
   onClose :() => void;
+  worksitePlanEKID :UUID;
 };
 
 const CheckInDetailsModal = ({
@@ -87,6 +88,7 @@ const CheckInDetailsModal = ({
   checkIn,
   isOpen,
   onClose,
+  worksitePlanEKID,
 } :Props) => {
 
   const deleteCheckInRequestState :RequestState = useSelector((store :Map) => store.getIn([
@@ -141,9 +143,9 @@ const CheckInDetailsModal = ({
     () => dispatch(deleteCheckIn({
       appointmentEKID,
       checkInToDelete: [{ entitySetId: checkInESID, entityKeyIds: [checkInEKID] }],
-      numberHoursWorked: -hoursWorked,
+      worksitePlanEKID,
     })),
-    [appointmentEKID, checkInEKID, checkInESID, dispatch, hoursWorked]
+    [appointmentEKID, checkInEKID, checkInESID, dispatch, worksitePlanEKID]
   );
 
   return (

--- a/src/containers/workschedule/AppointmentContainer.js
+++ b/src/containers/workschedule/AppointmentContainer.js
@@ -50,7 +50,7 @@ import {
 
 const { getStyleVariation } = StyleUtils;
 const { NEUTRAL, PURPLE, YELLOW } = Colors;
-const { CHECK_INS_BY_APPOINTMENT, WORKSITES_BY_WORKSITE_PLAN } = WORKSITE_PLANS;
+const { CHECK_INS_BY_APPOINTMENT, WORKSITES_BY_WORKSITE_PLAN, WORKSITE_PLAN_EKID_BY_APPOINTMENT_EKID } = WORKSITE_PLANS;
 const { PARTICIPANT } = PERSON;
 const { PERSON_BY_APPOINTMENT_EKID } = WORK_SCHEDULE;
 const { ENTITY_KEY_ID, FIRST_NAME, LAST_NAME } = PROPERTY_TYPE_FQNS;
@@ -109,6 +109,7 @@ type Props = {
   participant :Map;
   personByAppointmentEKID :Map;
   result :Map;
+  worksitePlanEKIDByAppointmentEKID :Map;
   worksitesByWorksitePlan :Map;
 };
 
@@ -117,6 +118,7 @@ const AppointmentContainer = ({
   participant,
   personByAppointmentEKID,
   result,
+  worksitePlanEKIDByAppointmentEKID,
   worksitesByWorksitePlan,
 } :Props) => {
 
@@ -139,7 +141,6 @@ const AppointmentContainer = ({
     setHours(storedHours);
     setNumHours(hoursScheduled);
   }, [result]);
-
   const personName = result.get('personName');
   const worksiteName = result.get('worksiteName');
   const courtType = result.get('courtType');
@@ -173,6 +174,8 @@ const AppointmentContainer = ({
     checkedInSymbol = ExclamationIcon;
   }
   const hoursToDisplay = getHoursForDisplay(numHours, checkIn);
+
+  const worksitePlanEKID :UUID = worksitePlanEKIDByAppointmentEKID.get(appointmentEKID, '');
 
   const goToParticipantProfile = useGoToRoute(
     Routes.PARTICIPANT_PROFILE.replace(':participantId', personEKID)
@@ -247,7 +250,8 @@ const AppointmentContainer = ({
           appointmentEKID={appointmentEKID}
           checkIn={checkIn}
           isOpen={isCheckInDetailsModalVisible}
-          onClose={() => handleCheckInDetailsModalVisibility(false)} />
+          onClose={() => handleCheckInDetailsModalVisibility(false)}
+          worksitePlanEKID={worksitePlanEKID} />
       <DeleteAppointmentModal
           appointment={result}
           appointmentEKID={appointmentEKID}
@@ -275,6 +279,7 @@ const mapStateToProps = (state :Map) => {
     [PARTICIPANT]: person.get(PARTICIPANT),
     [PERSON_BY_APPOINTMENT_EKID]: workSchedule.get(PERSON_BY_APPOINTMENT_EKID),
     [WORKSITES_BY_WORKSITE_PLAN]: worksitePlans.get(WORKSITES_BY_WORKSITE_PLAN),
+    [WORKSITE_PLAN_EKID_BY_APPOINTMENT_EKID]: worksitePlans.get(WORKSITE_PLAN_EKID_BY_APPOINTMENT_EKID),
   });
 };
 

--- a/src/utils/constants/ReduxStateConsts.js
+++ b/src/utils/constants/ReduxStateConsts.js
@@ -253,6 +253,7 @@ export const WORKSITE_PLANS = {
   UPDATE_HOURS_WORKED: 'updateHoursWorked',
   WORKSITES_BY_WORKSITE_PLAN: 'worksitesByWorksitePlan',
   WORKSITE_PLANS_LIST: 'worksitePlansList',
+  WORKSITE_PLAN_EKID_BY_APPOINTMENT_EKID: 'worksitePlanEKIDByAppointmentEKID',
   WORKSITE_PLAN_STATUSES: 'worksitePlanStatuses',
   WORK_APPOINTMENTS_BY_WORKSITE_PLAN: 'workAppointmentsByWorksitePlan',
 };


### PR DESCRIPTION
Changing up how worksite plan's `hours worked` are managed.

1) Remove "hours worked" field from Edit Worksite Plan (Assigned Worksite). The user will not be able to edit the hours worked on the worksite plan directly anymore, which prevent the possibility of worksite plan hours getting out of sync with actual worked hours:

![Screen Shot 2021-04-21 at 10 59 09 AM](https://user-images.githubusercontent.com/32921059/115603733-5c760f80-a295-11eb-82b1-cb74216eb9ca.png)


2) In the actual `updateHoursWorked` saga, rather than relying on the current transaction (i.e. either creating a check-in or deleting a check-in) to determine what the current worksite plan "hours worked" should be, perform the check-in transaction first, and then update hours worked based on what the total hours count is from all related check-ins.

create a check-in that matches scheduled hours:
![0b660228d6447c28a2652aa987e58eea](https://user-images.githubusercontent.com/32921059/115603964-a959e600-a295-11eb-8913-8458ec767379.gif)

create a check-in that does not match scheduled hours:
![ee71188e300b226ade2a06943e20fd9a](https://user-images.githubusercontent.com/32921059/115603973-abbc4000-a295-11eb-980e-62f66f6f1f63.gif)

remove a check-in:
![56618235f8ed2165c919f1e1c8134a0d](https://user-images.githubusercontent.com/32921059/115604016-b971c580-a295-11eb-922e-51281c3a7118.gif)

