### PR TITLE
bugfix/APPS-2872 — show only relevant worksites in Edit Appointment

### DIFF
--- a/src/containers/workschedule/WorkScheduleSagas.js
+++ b/src/containers/workschedule/WorkScheduleSagas.js
@@ -170,67 +170,52 @@ function* getWorksitePlansByPersonWorker(action :SequenceAction) :Generator<*, *
     yield put(getWorksitePlansByPerson.request(id));
     const { value } = action;
     if (!isDefined(value)) throw ERR_ACTION_VALUE_NOT_DEFINED;
-    const { personEKIDs } = value;
+    const {
+      diversionPlanByWorksitePlan,
+      peopleByWorksitePlan,
+      worksitePlansByDiversionPlanEKID,
+    } = value;
 
-    const app = yield select(getAppFromState);
-    const worksitePlanESID :UUID = getEntitySetIdFromApp(app, WORKSITE_PLAN);
-    const peopleESID :UUID = getEntitySetIdFromApp(app, PEOPLE);
-
-    let searchFilter :Object = {
-      entityKeyIds: personEKIDs,
-      destinationEntitySetIds: [worksitePlanESID],
-      sourceEntitySetIds: [],
-    };
-    response = yield call(
-      searchEntityNeighborsWithFilterWorker,
-      searchEntityNeighborsWithFilter({ entitySetId: peopleESID, filter: searchFilter })
-    );
-    if (response.error) throw response.error;
     const worksitePlanEKIDs :UUID[] = [];
-    const personEKIDByWorksitePlanEKID :Map = Map().asMutable();
 
-    let worksitesByWorksitePlanEKIDByPersonEKID :Map = Map().withMutations((map :Map) => {
-      fromJS(response.data).forEach((neighborsList :List, personEKID :UUID) => {
-        neighborsList.forEach((worksitePlanNeighbor :Map) => {
-          const worksitePlanEKID :UUID = getEntityKeyId(getNeighborDetails(worksitePlanNeighbor));
+    const personEKIDByWorksitePlanEKID :Map = Map().withMutations((mutator) => {
+      peopleByWorksitePlan.forEach((person :Map, worksitePlanEKIDForAppointment :UUID) => {
+        const diversionPlanEKID :UUID = diversionPlanByWorksitePlan.get(worksitePlanEKIDForAppointment, '');
+        const worksitePlans :List = worksitePlansByDiversionPlanEKID.get(diversionPlanEKID, List());
+        const personEKID :UUID = getEntityKeyId(person);
+        worksitePlans.forEach((worksitePlan :Map) => {
+          const worksitePlanEKID :UUID = getEntityKeyId(worksitePlan);
           worksitePlanEKIDs.push(worksitePlanEKID);
-
-          personEKIDByWorksitePlanEKID.set(worksitePlanEKID, personEKID);
-
-          let worksitesByWorksitePlanForCurrentPerson :Map = map.get(personEKID, Map());
-
-          if (!isDefined(worksitesByWorksitePlanForCurrentPerson.get(worksitePlanEKID))) {
-            worksitesByWorksitePlanForCurrentPerson = worksitesByWorksitePlanForCurrentPerson
-              .set(worksitePlanEKID, Map());
-          }
-          map.set(personEKID, worksitesByWorksitePlanForCurrentPerson);
+          mutator.set(worksitePlanEKID, personEKID);
         });
       });
     });
 
+    const app = yield select(getAppFromState);
+    const worksitePlanESID :UUID = getEntitySetIdFromApp(app, WORKSITE_PLAN);
     const worksiteESID :UUID = getEntitySetIdFromApp(app, WORKSITE);
-    searchFilter = {
+
+    const filter = {
       entityKeyIds: worksitePlanEKIDs,
       destinationEntitySetIds: [worksiteESID],
       sourceEntitySetIds: [],
     };
     response = yield call(
       searchEntityNeighborsWithFilterWorker,
-      searchEntityNeighborsWithFilter({ entitySetId: worksitePlanESID, filter: searchFilter })
+      searchEntityNeighborsWithFilter({ entitySetId: worksitePlanESID, filter })
     );
     if (response.error) throw response.error;
 
-    fromJS(response.data).forEach((neighborsList :List, worksitePlanEKID :UUID) => {
-      const worksite :Map = getNeighborDetails(neighborsList.get(0));
-      const personEKID :UUID = personEKIDByWorksitePlanEKID.get(worksitePlanEKID, '');
-      let worksitesByWorksitePlanEKID :Map = worksitesByWorksitePlanEKIDByPersonEKID.get(personEKID, Map());
-      if (isDefined(worksitesByWorksitePlanEKID.get(worksitePlanEKID))) {
-        worksitesByWorksitePlanEKID = worksitesByWorksitePlanEKID.set(worksitePlanEKID, worksite);
-      }
-      worksitesByWorksitePlanEKIDByPersonEKID = worksitesByWorksitePlanEKIDByPersonEKID
-        .set(personEKID, worksitesByWorksitePlanEKID);
+    const worksitesByWorksitePlanEKIDByPersonEKID :Map = Map().withMutations((mutator) => {
+      fromJS(response.data).forEach((worksiteNeighborsList :List, worksitePlanEKID :UUID) => {
+        const worksite :Map = getNeighborDetails(worksiteNeighborsList.get(0, Map()));
+        const personEKID :UUID = personEKIDByWorksitePlanEKID.get(worksitePlanEKID, '');
+        const worksitesByWorksitePlanEKIDS = mutator.get(personEKID, Map());
+        mutator.set(personEKID, worksitesByWorksitePlanEKIDS.set(worksitePlanEKID, worksite));
+      });
     });
 
+    workerResponse.data = worksitesByWorksitePlanEKIDByPersonEKID;
     yield put(getWorksitePlansByPerson.success(id, worksitesByWorksitePlanEKIDByPersonEKID));
   }
   catch (error) {

--- a/src/containers/workschedule/WorkScheduleSagas.js
+++ b/src/containers/workschedule/WorkScheduleSagas.js
@@ -298,9 +298,10 @@ function* getWorksiteAndPersonNamesWorker(action :SequenceAction) :Generator<*, 
 
     const worksiteESID :UUID = getEntitySetIdFromApp(app, WORKSITE);
     const peopleESID :UUID = getEntitySetIdFromApp(app, PEOPLE);
+    const diversionPlanESID :UUID = getEntitySetIdFromApp(app, DIVERSION_PLAN);
     const worksiteFilter = {
       entityKeyIds: worksitePlanEKIDs,
-      destinationEntitySetIds: [worksiteESID],
+      destinationEntitySetIds: [diversionPlanESID, worksiteESID],
       sourceEntitySetIds: [peopleESID],
     };
     response = yield call(
@@ -312,7 +313,9 @@ function* getWorksiteAndPersonNamesWorker(action :SequenceAction) :Generator<*, 
     }
     let worksitesByWorksitePlan :Map = Map();
     let peopleByWorksitePlan :Map = Map();
+    let diversionPlanByWorksitePlan :Map = Map();
     const personEKIDs :UUID[] = [];
+    const diversionPlanEKIDs :UUID[] = [];
 
     fromJS(response.data)
       .forEach((neighborsList :List, worksitePlanEKID :UUID) => {
@@ -324,6 +327,11 @@ function* getWorksiteAndPersonNamesWorker(action :SequenceAction) :Generator<*, 
           if (getNeighborESID(neighbor) === peopleESID) {
             personEKIDs.push(getEntityKeyId(entity));
             peopleByWorksitePlan = peopleByWorksitePlan.set(worksitePlanEKID, entity);
+          }
+          if (getNeighborESID(neighbor) === diversionPlanESID) {
+            const diversionPlanEKID :UUID = getEntityKeyId(entity);
+            diversionPlanByWorksitePlan = diversionPlanByWorksitePlan.set(worksitePlanEKID, diversionPlanEKID);
+            diversionPlanEKIDs.push(diversionPlanEKID);
           }
         });
       });


### PR DESCRIPTION
The "Edit Appointment" modal has a dropdown of worksites that the user can use to update the worksite at which the work appointment should be scheduled. Specifically on the Work Schedule tab, the dropdown was being populated by all assigned worksites ever for the person whose appointment it is, instead of the worksites that they are working at as part of their current enrollment (`diversion plan`). The user shouldn't actually be able to change the worksite to a previously worked-at worksite, only the ones that are currently active, so I updated this to only show worksites associated with the relevant enrollment/`diversion plan`.

for reference, this participant has 2 previous enrollments that include several other assigned worksites, but the modal now only shows the worksite for this current enrollment:
![Screen Shot 2021-04-21 at 1 31 28 PM](https://user-images.githubusercontent.com/32921059/115617633-7b30d200-a2a6-11eb-9501-87d5469ffe65.png)
