### PR TITLE
bugfix/APPS-2963 — check-in not updating hours worked

### DIFF
--- a/src/containers/participant/schedule/CheckInForm.js
+++ b/src/containers/participant/schedule/CheckInForm.js
@@ -45,7 +45,7 @@ const {
   CHECK_INS,
   CHECK_IN_DETAILS,
   FULFILLS,
-  HAS,
+  RELATED_TO,
   PEOPLE,
 } = APP_TYPE_FQNS;
 const {
@@ -214,9 +214,9 @@ class CheckInForm extends Component<Props, State> {
     const appointmentEKID :UUID = appointment.get(ENTITY_KEY_ID);
     const associations = [];
 
-    associations.push([HAS, personEKID, PEOPLE, 0, CHECK_INS, {}]);
+    associations.push([RELATED_TO, personEKID, PEOPLE, 0, CHECK_INS, {}]);
     associations.push([FULFILLS, 0, CHECK_INS, appointmentEKID, APPOINTMENT, {}]);
-    associations.push([HAS, 0, CHECK_INS, 0, CHECK_IN_DETAILS, {}]);
+    associations.push([RELATED_TO, 0, CHECK_INS, 0, CHECK_IN_DETAILS, {}]);
 
     const entityData :{} = processEntityData(newCheckInData, entitySetIds, propertyTypeIds);
     const associationEntityData :{} = processAssociationEntityData(fromJS(associations), entitySetIds, propertyTypeIds);


### PR DESCRIPTION
in the UI, checking in a work appointment appeared to be successful when submitted, but then refreshing the page would show that the hours worked were missing on the check-in itself, plus the assigned worksite's hours had not been updated. the problem was with this association: `check-in -> has -> check-in details`. the submitting of entity/association data for the check-in returns successfully and returns EKIDs for the new entities/associations, but then when i try to fetch the `has` association from the entity set `073ee9e0-a840-4b23-a8ce-b5a5a056bf2a` (in postman), it doesn't exist. so, the neighbors search for check-in details neighbors of check-ins doesn't return the new entities, on which the hours worked are stored. the permissions are correct on the `has` association entity set, so i'm not sure what the root of the issue is. for the meantime, while i look into that, i changed the association to `related to` to unblock the CWP users who use this feature quite a lot. when `check-in -> related to -> check-in details` is what's submitted upon creating check-ins, there's no issue with fetching check-in details neighbors of check-ins.

NOTE: this entity set `073ee9e0-a840-4b23-a8ce-b5a5a056bf2a` does not appear in the orgs app under Pennington, SD even though it's definitely a part of that org... i was able to check permissions on gallery.