### PR TITLE
Task/APPS-3048 — update stats

### DIFF
--- a/src/containers/stats/StatsContainer.js
+++ b/src/containers/stats/StatsContainer.js
@@ -164,7 +164,7 @@ const StatsBoxSkeleton = () => (
     </StatsRow>
     <StatsRow>
       {
-        [0, 1].map((num) => (
+        [0, 1, 2].map((num) => (
           <StatBox key={num}>
             <Skeleton height={48} width="48px" />
             <StatBoxInnerWrapper>

--- a/src/containers/stats/charges/ChargesGraphs.js
+++ b/src/containers/stats/charges/ChargesGraphs.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+
 import styled from 'styled-components';
 import { List, Map } from 'immutable';
 import { Button, CardStack } from 'lattice-ui-kit';
@@ -7,19 +8,20 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import type { RequestSequence, RequestState } from 'redux-reqseq';
 
+import { DOWNLOAD_CHARGES_STATS, downloadChargesStats } from './ChargesStatsActions';
+
 import ChargesHeadCell from '../../../components/table/ChargesHeadCell';
 import ChargesTableRow from '../../../components/table/ChargesTableRow';
 import TableHeaderRow from '../../../components/table/TableHeaderRow';
 import {
-  TableCell,
   CustomTable,
   TableCard,
+  TableCell,
   TableHeader,
   TableName,
 } from '../../../components/table/styled/index';
 import { generateTableHeaders } from '../../../utils/FormattingUtils';
 import { requestIsPending } from '../../../utils/RequestStateUtils';
-import { DOWNLOAD_CHARGES_STATS, downloadChargesStats } from './ChargesStatsActions';
 import { SHARED, STATE, STATS } from '../../../utils/constants/ReduxStateConsts';
 import { ARREST_CHARGE_HEADERS, COURT_CHARGE_HEADERS } from '../consts/StatsConsts';
 
@@ -73,7 +75,7 @@ const ChargesGraphs = ({
 } :Props) => (
   <CardStack>
     <TableCard>
-      <ChargesTableHeader padding="40px">
+      <ChargesTableHeader padding="40px" vertical={false}>
         <TableName>
           Arrest Charges
         </TableName>
@@ -90,7 +92,7 @@ const ChargesGraphs = ({
           isLoading={false} />
     </TableCard>
     <TableCard>
-      <ChargesTableHeader padding="40px">
+      <ChargesTableHeader padding="40px" vertical={false}>
         <TableName>
           Court Charges
         </TableName>

--- a/src/containers/stats/courttype/CourtTypeSagas.js
+++ b/src/containers/stats/courttype/CourtTypeSagas.js
@@ -49,11 +49,13 @@ import {
   getNeighborESID,
   getPropertyTypeIdFromEdm,
   getUTCDateRangeSearchString,
+  sortEntitiesByDateProperty,
 } from '../../../utils/DataUtils';
 import { ERR_ACTION_VALUE_NOT_DEFINED } from '../../../utils/Errors';
 import { isDefined, isEmptyString } from '../../../utils/LangUtils';
 import { getPersonFullName } from '../../../utils/PeopleUtils';
 import { STATE } from '../../../utils/constants/ReduxStateConsts';
+import { COMPLETION_STATUSES } from '../../participants/ParticipantsConstants';
 import { ACTIVE_STATUSES, courtTypeCountObj } from '../consts/CourtTypeConsts';
 import { DOWNLOAD_CONSTS } from '../consts/StatsConsts';
 import { ALL_TIME, MONTHLY, YEARLY } from '../consts/TimeConsts';
@@ -62,7 +64,7 @@ const { getEntitySetData } = DataApiActions;
 const { getEntitySetDataWorker } = DataApiSagas;
 const { searchEntitySetData, searchEntityNeighborsWithFilter } = SearchApiActions;
 const { searchEntitySetDataWorker, searchEntityNeighborsWithFilterWorker } = SearchApiSagas;
-const { getEntityKeyId } = DataUtils;
+const { getEntityKeyId, getPropertyValue } = DataUtils;
 const {
   APPOINTMENT,
   CHECK_INS,
@@ -966,42 +968,68 @@ function* getEnrollmentsByCourtTypeWorker(action :SequenceAction) :Generator<*, 
     const edm = yield select(getEdmFromState);
     const enrollmentStatusESID :UUID = getEntitySetIdFromApp(app, ENROLLMENT_STATUS);
     const effectiveDatePTID :UUID = getPropertyTypeIdFromEdm(edm, EFFECTIVE_DATE);
-    const searchOptions = {
-      entitySetIds: [enrollmentStatusESID],
-      start: 0,
-      maxHits: 10000,
-      constraints: []
-    };
 
-    let searchTerm :string = '';
-
-    if (timeFrame === MONTHLY) {
-      const mmMonth :string = month < 10 ? `0${month}` : month;
-      const firstDateOfMonth :DateTime = DateTime.fromISO(`${year}-${mmMonth}-01`);
-      searchTerm = getUTCDateRangeSearchString(effectiveDatePTID, 'month', firstDateOfMonth);
-    }
-    else if (timeFrame === YEARLY) {
-      const firstDateOfYear :DateTime = DateTime.fromISO(`${year}-01-01`);
-      searchTerm = getUTCDateRangeSearchString(effectiveDatePTID, 'year', firstDateOfYear);
-    }
-    searchOptions.constraints.push({
-      min: 1,
-      constraints: [{
-        searchTerm,
-        fuzzy: false
-      }]
-    });
-    response = yield call(searchEntitySetDataWorker, searchEntitySetData(searchOptions));
-    if (response.error) throw response.error;
-    const enrollmentStatuses :List = fromJS(response.data.hits);
     const enrollmentStatusEKIDs :UUID[] = [];
-    const enrollmentStatusByEKID :Map = Map().withMutations((map :Map) => {
-      enrollmentStatuses.forEach((enrollmentStatus :Map) => {
-        const enrollmentStatusEKID :?UUID = getEntityKeyId(enrollmentStatus);
-        if (enrollmentStatusEKID) enrollmentStatusEKIDs.push(enrollmentStatusEKID);
-        map.set(enrollmentStatusEKID, enrollmentStatus);
+    let enrollmentStatusByEKID :Map = Map();
+
+    if (timeFrame === ALL_TIME) {
+      response = yield call(getEntitySetDataWorker, getEntitySetData({ entitySetId: enrollmentStatusESID }));
+      if (response.error) throw response.error;
+      fromJS(response.data).forEach((enrollmentStatus) => {
+        const effectiveDateTime = getPropertyValue(enrollmentStatus, [EFFECTIVE_DATE, 0], undefined);
+        const status = getPropertyValue(enrollmentStatus, [STATUS, 0], undefined);
+        if (isDefined(effectiveDateTime) && isDefined(status)) {
+          const enrollmentStatusEKID = getEntityKeyId(enrollmentStatus);
+          if (enrollmentStatusEKID) {
+            enrollmentStatusEKIDs.push(enrollmentStatusEKID);
+            enrollmentStatusByEKID = enrollmentStatusByEKID.set(enrollmentStatusEKID, enrollmentStatus);
+          }
+        }
       });
-    });
+    }
+    else {
+      const searchOptions = {
+        entitySetIds: [enrollmentStatusESID],
+        start: 0,
+        maxHits: 10000,
+        constraints: []
+      };
+
+      let searchTerm :string = '';
+
+      if (timeFrame === MONTHLY) {
+        const mmMonth :string = month < 10 ? `0${month}` : month;
+        const firstDateOfMonth :DateTime = DateTime.fromISO(`${year}-${mmMonth}-01`);
+        searchTerm = getUTCDateRangeSearchString(effectiveDatePTID, 'month', firstDateOfMonth);
+      }
+      else if (timeFrame === YEARLY) {
+        const firstDateOfYear :DateTime = DateTime.fromISO(`${year}-01-01`);
+        searchTerm = getUTCDateRangeSearchString(effectiveDatePTID, 'year', firstDateOfYear);
+      }
+      searchOptions.constraints.push({
+        min: 1,
+        constraints: [{
+          searchTerm,
+          fuzzy: false
+        }]
+      });
+      response = yield call(searchEntitySetDataWorker, searchEntitySetData(searchOptions));
+      if (response.error) throw response.error;
+      const enrollmentStatuses :List = fromJS(response.data.hits);
+      enrollmentStatusByEKID = Map().withMutations((map :Map) => {
+        enrollmentStatuses.forEach((enrollmentStatus :Map) => {
+          const effectiveDateTime = getPropertyValue(enrollmentStatus, [EFFECTIVE_DATE, 0], undefined);
+          const status = getPropertyValue(enrollmentStatus, [STATUS, 0], undefined);
+          if (isDefined(effectiveDateTime) && isDefined(status)) {
+            const enrollmentStatusEKID :?UUID = getEntityKeyId(enrollmentStatus);
+            if (enrollmentStatusEKID) {
+              enrollmentStatusEKIDs.push(enrollmentStatusEKID);
+              map.set(enrollmentStatusEKID, enrollmentStatus);
+            }
+          }
+        });
+      });
+    }
 
     if (enrollmentStatusEKIDs.length) {
       const diversionPlanESID :UUID = getEntitySetIdFromApp(app, DIVERSION_PLAN);
@@ -1042,62 +1070,70 @@ function* getEnrollmentsByCourtTypeWorker(action :SequenceAction) :Generator<*, 
         const courtCaseNeighbors :Map = fromJS(response.data);
         courtCaseNeighbors.forEach((neighborsList :List, diversionPlanEKID :UUID) => {
           const courtCase :Map = getNeighborDetails(neighborsList.get(0));
-          const { [COURT_CASE_TYPE]: courtType } = getEntityProperties(courtCase, [COURT_CASE_TYPE]);
-          const enrollmentStatusesForDiversionPlan :List = enrollmentStatusEKIDsByDiversionPlanEKID
+          const courtType = getPropertyValue(courtCase, [COURT_CASE_TYPE, 0]);
+          const enrollmentStatusEKIDsForDiversionPlan :List = enrollmentStatusEKIDsByDiversionPlanEKID
             .get(diversionPlanEKID, List());
-          /*
-            i'll add all enrollment statuses here, but this could be revised to use only the most
-            recent enrollment status, so enrollments (diversionPlans) aren't double counted:
-          */
-          enrollmentStatusesForDiversionPlan.forEach((enrollmentStatusEKID :UUID) => {
-            const enrollmentStatus :Map = enrollmentStatusByEKID.get(enrollmentStatusEKID, Map());
-            const {
-              [EFFECTIVE_DATE]: effectiveDateTime,
-              [STATUS]: status
-            } = getEntityProperties(enrollmentStatus, [EFFECTIVE_DATE, STATUS]);
 
-            if (ACTIVE_STATUSES.includes(status)) {
-              const count :number = activeEnrollmentsByCourtType.get(courtType, 0);
-              activeEnrollmentsByCourtType = activeEnrollmentsByCourtType.set(courtType, count + 1);
+          // find the most recent enrollment status for the diversion plan
+          const enrollmentStatuses = enrollmentStatusEKIDsForDiversionPlan
+            .map((enrollmentStatusEKID :UUID) => enrollmentStatusByEKID.get(enrollmentStatusEKID, Map()));
+          let sortedEnrollmentStatuses = sortEntitiesByDateProperty(enrollmentStatuses, [EFFECTIVE_DATE]);
+          sortedEnrollmentStatuses = sortedEnrollmentStatuses.sort((enrollmentStatus :Map) => {
+            const status = getPropertyValue(enrollmentStatus, [STATUS, 0]);
+            if (status === ENROLLMENT_STATUSES.AWAITING_CHECKIN) return -1;
+            return 0;
+          });
+          const completionStatus :?Map = sortedEnrollmentStatuses.find((enrollmentStatus :Map) => {
+            const status = getPropertyValue(enrollmentStatus, [STATUS, 0]);
+            return COMPLETION_STATUSES.includes(status);
+          });
+          const mostRecentStatus :Map = completionStatus || sortedEnrollmentStatuses.last() || Map();
 
-              if (status === ENROLLMENT_STATUSES.ACTIVE) {
-                const effectiveDateAsDateTime = DateTime.fromISO(effectiveDateTime);
-                const becameActiveCount :number = becameActiveEnrollmentsByCourtType.get(courtType, 0);
-                if (timeFrame === MONTHLY) {
-                  if (month === effectiveDateAsDateTime.month && year === effectiveDateAsDateTime.year) {
-                    becameActiveEnrollmentsByCourtType = becameActiveEnrollmentsByCourtType
-                      .set(courtType, becameActiveCount + 1);
-                  }
+          // distribute enrollments by status and court type:
+          const effectiveDateTime = getPropertyValue(mostRecentStatus, [EFFECTIVE_DATE, 0]);
+          const status = getPropertyValue(mostRecentStatus, [STATUS, 0]);
+
+          if (ACTIVE_STATUSES.includes(status)) {
+            const count :number = activeEnrollmentsByCourtType.get(courtType, 0);
+            activeEnrollmentsByCourtType = activeEnrollmentsByCourtType.set(courtType, count + 1);
+
+            if (status === ENROLLMENT_STATUSES.ACTIVE) {
+              const effectiveDateAsDateTime = DateTime.fromISO(effectiveDateTime);
+              const becameActiveCount :number = becameActiveEnrollmentsByCourtType.get(courtType, 0);
+              if (timeFrame === MONTHLY) {
+                if (month === effectiveDateAsDateTime.month && year === effectiveDateAsDateTime.year) {
+                  becameActiveEnrollmentsByCourtType = becameActiveEnrollmentsByCourtType
+                    .set(courtType, becameActiveCount + 1);
                 }
-                else if (timeFrame === YEARLY) {
-                  if (year === effectiveDateAsDateTime.year) {
-                    becameActiveEnrollmentsByCourtType = becameActiveEnrollmentsByCourtType
-                      .set(courtType, becameActiveCount + 1);
-                  }
+              }
+              else if (timeFrame === YEARLY) {
+                if (year === effectiveDateAsDateTime.year) {
+                  becameActiveEnrollmentsByCourtType = becameActiveEnrollmentsByCourtType
+                    .set(courtType, becameActiveCount + 1);
                 }
               }
             }
-            if (status === ENROLLMENT_STATUSES.JOB_SEARCH) {
-              const count :number = jobSearchEnrollmentsByCourtType.get(courtType, 0);
-              jobSearchEnrollmentsByCourtType = jobSearchEnrollmentsByCourtType
-                .set(courtType, count + 1);
-            }
-            if (status === ENROLLMENT_STATUSES.COMPLETED || status === ENROLLMENT_STATUSES.SUCCESSFUL) {
-              const count :number = successfulEnrollmentsByCourtType.get(courtType, 0);
-              successfulEnrollmentsByCourtType = successfulEnrollmentsByCourtType
-                .set(courtType, count + 1);
-            }
-            if (status === ENROLLMENT_STATUSES.REMOVED_NONCOMPLIANT || status === ENROLLMENT_STATUSES.UNSUCCESSFUL) {
-              const count :number = unsuccessfulEnrollmentsByCourtType.get(courtType, 0);
-              unsuccessfulEnrollmentsByCourtType = unsuccessfulEnrollmentsByCourtType
-                .set(courtType, count + 1);
-            }
-            if (status === ENROLLMENT_STATUSES.CLOSED) {
-              const count :number = closedEnrollmentsByCourtType.get(courtType, 0);
-              closedEnrollmentsByCourtType = closedEnrollmentsByCourtType
-                .set(courtType, count + 1);
-            }
-          });
+          }
+          if (status === ENROLLMENT_STATUSES.JOB_SEARCH) {
+            const count :number = jobSearchEnrollmentsByCourtType.get(courtType, 0);
+            jobSearchEnrollmentsByCourtType = jobSearchEnrollmentsByCourtType
+              .set(courtType, count + 1);
+          }
+          if (status === ENROLLMENT_STATUSES.COMPLETED || status === ENROLLMENT_STATUSES.SUCCESSFUL) {
+            const count :number = successfulEnrollmentsByCourtType.get(courtType, 0);
+            successfulEnrollmentsByCourtType = successfulEnrollmentsByCourtType
+              .set(courtType, count + 1);
+          }
+          if (status === ENROLLMENT_STATUSES.REMOVED_NONCOMPLIANT || status === ENROLLMENT_STATUSES.UNSUCCESSFUL) {
+            const count :number = unsuccessfulEnrollmentsByCourtType.get(courtType, 0);
+            unsuccessfulEnrollmentsByCourtType = unsuccessfulEnrollmentsByCourtType
+              .set(courtType, count + 1);
+          }
+          if (status === ENROLLMENT_STATUSES.CLOSED) {
+            const count :number = closedEnrollmentsByCourtType.get(courtType, 0);
+            closedEnrollmentsByCourtType = closedEnrollmentsByCourtType
+              .set(courtType, count + 1);
+          }
         });
       }
     }

--- a/src/containers/stats/courttype/CourtTypeSagas.js
+++ b/src/containers/stats/courttype/CourtTypeSagas.js
@@ -461,9 +461,9 @@ function* getTotalParticipantsByCourtTypeWorker(action :SequenceAction) :Generat
       response = yield call(searchEntitySetDataWorker, searchEntitySetData(searchOptions));
       if (response.error) throw response.error;
       const diversionPlans :List = fromJS(response.data.hits);
-      fromJS(response.data).forEach((plan :Map) => {
+      diversionPlans.forEach((plan :Map) => {
         const planEKID :?UUID = getEntityKeyId(plan);
-        if (planEKID) diversionPlans.push(planEKID);
+        if (planEKID) diversionPlanEKIDs.push(planEKID);
       });
     }
 
@@ -491,10 +491,7 @@ function* getTotalParticipantsByCourtTypeWorker(action :SequenceAction) :Generat
             .find((neighbor :Map) => getNeighborESID(neighbor) === courtCaseESID);
 
           if (isDefined(courtCaseNeighbor)) {
-            const { [COURT_CASE_TYPE]: courtType } = getEntityProperties(
-              getNeighborDetails(courtCaseNeighbor),
-              [COURT_CASE_TYPE]
-            );
+            const courtType = getPropertyValue(getNeighborDetails(courtCaseNeighbor), [COURT_CASE_TYPE, 0]);
 
             const personEKID :?UUID = getEntityKeyId(getNeighborDetails(personNeighbor));
             let personCourtTypes :List = map.get(personEKID, List());

--- a/src/containers/stats/courttype/EnrollmentsAndStatusByCourtType.js
+++ b/src/containers/stats/courttype/EnrollmentsAndStatusByCourtType.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 import { List, Map } from 'immutable';
@@ -138,31 +138,20 @@ const EnrollmentsAndStatusByCourtType = ({
   const [enrollmentsMonth, setEnrollmentsMonth] = useState(MONTHS_OPTIONS[today.month - 1]);
   const currentYearOption :Object = YEARS_OPTIONS.find((obj) => obj.value === today.year);
   const [enrollmentsYear, setEnrollmentsYear] = useState(currentYearOption);
-  const onTimeFrameSelectChange = (option :Object) => {
-    if (option.value === ALL_TIME) {
-      actions.getStatsData();
-      setTimeFrame(option);
-    }
-    else setTimeFrame(option);
+
+  const onChangeSelect = (selectedTimeValue :Object, event :Object) => {
+    if (event.name === 'month') setEnrollmentsMonth(selectedTimeValue);
+    if (event.name === 'year') setEnrollmentsYear(selectedTimeValue);
+    if (event.name === 'timeframe') setTimeFrame(selectedTimeValue);
   };
 
-  const onChangeMonth = (newMonth :Object) => {
-    setEnrollmentsMonth(newMonth);
+  useEffect(() => {
     actions.getEnrollmentsByCourtType({
-      month: newMonth.value,
+      month: enrollmentsMonth.value,
       year: enrollmentsYear.value,
       timeFrame: timeFrame.value
     });
-  };
-
-  const onChangeYear = (newYear :Object) => {
-    setEnrollmentsYear(newYear);
-    actions.getEnrollmentsByCourtType({
-      month: enrollmentsMonth.value,
-      year: newYear.value,
-      timeFrame: timeFrame.value
-    });
-  };
+  }, [actions, enrollmentsMonth, enrollmentsYear, timeFrame]);
 
   const downloadEnrollmentsData = () => {
     const formattedEnrollmentsData :List = formatEnrollmentsDataForDownload(
@@ -231,7 +220,8 @@ const EnrollmentsAndStatusByCourtType = ({
           <HeaderActionsWrapper>
             <SmallSelectWrapper>
               <Select
-                  onChange={onTimeFrameSelectChange}
+                  name="timeframe"
+                  onChange={onChangeSelect}
                   options={TIME_FRAME_OPTIONS}
                   placeholder={TIME_FRAME_OPTIONS[2].label} />
             </SmallSelectWrapper>
@@ -250,12 +240,12 @@ const EnrollmentsAndStatusByCourtType = ({
                   <Select
                       isDisabled={timeFrame.value === YEARLY}
                       name="month"
-                      onChange={onChangeMonth}
+                      onChange={onChangeSelect}
                       options={MONTHS_OPTIONS}
                       placeholder={MONTHS_OPTIONS[today.month - 1].label} />
                   <Select
                       name="year"
-                      onChange={onChangeYear}
+                      onChange={onChangeSelect}
                       options={YEARS_OPTIONS}
                       placeholder={today.year} />
                 </SelectsWrapper>

--- a/src/containers/stats/courttype/EnrollmentsAndStatusByCourtType.js
+++ b/src/containers/stats/courttype/EnrollmentsAndStatusByCourtType.js
@@ -2,15 +2,12 @@
 import React, { useState } from 'react';
 
 import styled from 'styled-components';
-import { faSearch } from '@fortawesome/pro-duotone-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { List, Map } from 'immutable';
 import {
   Button,
   Card,
   CardSegment,
   Colors,
-  IconButton,
   Select,
   Spinner,
 } from 'lattice-ui-kit';
@@ -148,10 +145,21 @@ const EnrollmentsAndStatusByCourtType = ({
     }
     else setTimeFrame(option);
   };
-  const getNewEnrollmentsData = () => {
+
+  const onChangeMonth = (newMonth :Object) => {
+    setEnrollmentsMonth(newMonth);
+    actions.getEnrollmentsByCourtType({
+      month: newMonth.value,
+      year: enrollmentsYear.value,
+      timeFrame: timeFrame.value
+    });
+  };
+
+  const onChangeYear = (newYear :Object) => {
+    setEnrollmentsYear(newYear);
     actions.getEnrollmentsByCourtType({
       month: enrollmentsMonth.value,
-      year: enrollmentsYear.value,
+      year: newYear.value,
       timeFrame: timeFrame.value
     });
   };
@@ -242,18 +250,15 @@ const EnrollmentsAndStatusByCourtType = ({
                   <Select
                       isDisabled={timeFrame.value === YEARLY}
                       name="month"
-                      onChange={setEnrollmentsMonth}
+                      onChange={onChangeMonth}
                       options={MONTHS_OPTIONS}
                       placeholder={MONTHS_OPTIONS[today.month - 1].label} />
                   <Select
                       name="year"
-                      onChange={setEnrollmentsYear}
+                      onChange={onChangeYear}
                       options={YEARS_OPTIONS}
                       placeholder={today.year} />
                 </SelectsWrapper>
-                <IconButton onClick={getNewEnrollmentsData}>
-                  <FontAwesomeIcon icon={faSearch} />
-                </IconButton>
               </ActionsWrapper>
             </InnerHeaderRow>
           )

--- a/src/containers/stats/courttype/HoursByCourtType.js
+++ b/src/containers/stats/courttype/HoursByCourtType.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { List, Map } from 'immutable';
 import {
@@ -35,7 +35,6 @@ import { requestIsPending } from '../../../utils/RequestStateUtils';
 import { SHARED, STATE, STATS } from '../../../utils/constants/ReduxStateConsts';
 import { getStatsData } from '../StatsActions';
 import {
-  ALL_TIME,
   MONTHLY,
   MONTHS_OPTIONS,
   TIME_FRAME_OPTIONS,
@@ -88,23 +87,15 @@ const HoursByCourtType = ({
   const currentYearOption :Object = YEARS_OPTIONS.find((obj) => obj.value === today.year);
   const [hoursYear, setHoursYear] = useState(currentYearOption);
 
-  const onTimeFrameSelectChange = (option :Object) => {
-    if (option.value === ALL_TIME) {
-      actions.getHoursByCourtType({ month: hoursMonth.value, year: hoursYear.value, timeFrame: ALL_TIME });
-      setTimeFrame(option);
-    }
-    else setTimeFrame(option);
+  const onChangeSelect = (selectedTimeValue :Object, event :Object) => {
+    if (event.name === 'month') setHoursMonth(selectedTimeValue);
+    if (event.name === 'year') setHoursYear(selectedTimeValue);
+    if (event.name === 'timeframe') setTimeFrame(selectedTimeValue);
   };
 
-  const onChangeMonth = (newMonth :Object) => {
-    setHoursMonth(newMonth);
-    actions.getHoursByCourtType({ month: newMonth.value, year: hoursYear.value, timeFrame: timeFrame.value });
-  };
-
-  const onChangeYear = (newYear :Object) => {
-    setHoursYear(newYear);
-    actions.getHoursByCourtType({ month: hoursMonth.value, year: newYear.value, timeFrame: timeFrame.value });
-  };
+  useEffect(() => {
+    actions.getHoursByCourtType({ month: hoursMonth.value, year: hoursYear.value, timeFrame: timeFrame.value });
+  }, [actions, hoursMonth, hoursYear, timeFrame]);
 
   const downloadParticipantsAndHoursData = () => {
     const formattedParticipantsAndHoursData :List = formatHoursByCourtTypeDataForDownload(
@@ -133,7 +124,8 @@ const HoursByCourtType = ({
           <HeaderActionsWrapper>
             <SmallSelectWrapper>
               <Select
-                  onChange={onTimeFrameSelectChange}
+                  name="timeframe"
+                  onChange={onChangeSelect}
                   options={TIME_FRAME_OPTIONS}
                   placeholder={TIME_FRAME_OPTIONS[0].label} />
             </SmallSelectWrapper>
@@ -152,12 +144,12 @@ const HoursByCourtType = ({
                   <Select
                       isDisabled={timeFrame.value === YEARLY}
                       name="month"
-                      onChange={onChangeMonth}
+                      onChange={onChangeSelect}
                       options={MONTHS_OPTIONS}
                       placeholder={MONTHS_OPTIONS[today.month - 1].label} />
                   <Select
                       name="year"
-                      onChange={onChangeYear}
+                      onChange={onChangeSelect}
                       options={YEARS_OPTIONS}
                       placeholder={today.year} />
                 </SelectsWrapper>

--- a/src/containers/stats/courttype/HoursByCourtType.js
+++ b/src/containers/stats/courttype/HoursByCourtType.js
@@ -1,15 +1,12 @@
 // @flow
 import React, { useState } from 'react';
 
-import { faSearch } from '@fortawesome/pro-duotone-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { List, Map } from 'immutable';
 import {
   Button,
   Card,
   CardSegment,
   Colors,
-  IconButton,
   Select,
   Spinner,
 } from 'lattice-ui-kit';
@@ -99,8 +96,14 @@ const HoursByCourtType = ({
     else setTimeFrame(option);
   };
 
-  const getNewHoursData = () => {
-    actions.getHoursByCourtType({ month: hoursMonth.value, year: hoursYear.value, timeFrame: timeFrame.value });
+  const onChangeMonth = (newMonth :Object) => {
+    setHoursMonth(newMonth);
+    actions.getHoursByCourtType({ month: newMonth.value, year: hoursYear.value, timeFrame: timeFrame.value });
+  };
+
+  const onChangeYear = (newYear :Object) => {
+    setHoursYear(newYear);
+    actions.getHoursByCourtType({ month: hoursMonth.value, year: newYear.value, timeFrame: timeFrame.value });
   };
 
   const downloadParticipantsAndHoursData = () => {
@@ -149,18 +152,15 @@ const HoursByCourtType = ({
                   <Select
                       isDisabled={timeFrame.value === YEARLY}
                       name="month"
-                      onChange={setHoursMonth}
+                      onChange={onChangeMonth}
                       options={MONTHS_OPTIONS}
                       placeholder={MONTHS_OPTIONS[today.month - 1].label} />
                   <Select
                       name="year"
-                      onChange={setHoursYear}
+                      onChange={onChangeYear}
                       options={YEARS_OPTIONS}
                       placeholder={today.year} />
                 </SelectsWrapper>
-                <IconButton onClick={getNewHoursData}>
-                  <FontAwesomeIcon icon={faSearch} />
-                </IconButton>
               </ActionsWrapper>
             </InnerHeaderRow>
           )

--- a/src/containers/stats/courttype/MonthlyParticipantsByCourtType.js
+++ b/src/containers/stats/courttype/MonthlyParticipantsByCourtType.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { List, Map } from 'immutable';
 import {
@@ -63,21 +63,17 @@ const MonthlyParticipantsByCourtTypeList = ({ actions, monthlyParticipantsByCour
   const currentYearOption :Object = YEARS_OPTIONS.find((obj) => obj.value === today.year);
   const [year, setYear] = useState(currentYearOption);
 
-  const onChangeMonth = (newMonth :Object) => {
-    setMonth(newMonth);
-    actions.getMonthlyParticipantsByCourtType({
-      month: newMonth.value,
-      year: year.value,
-    });
+  const onChangeSelect = (selectedTimeValue :Object, event :Object) => {
+    if (event.name === 'month') setMonth(selectedTimeValue);
+    if (event.name === 'year') setYear(selectedTimeValue);
   };
 
-  const onChangeYear = (newYear :Object) => {
-    setYear(newYear);
+  useEffect(() => {
     actions.getMonthlyParticipantsByCourtType({
       month: month.value,
-      year: newYear.value,
+      year: year.value,
     });
-  };
+  }, [actions, month, year]);
 
   const downloadParticipantsByCourtType = () => {
     const formattedData :List = formatParticipantsByCourtTypeDataForDownload(monthlyParticipantsByCourtType);
@@ -105,12 +101,12 @@ const MonthlyParticipantsByCourtTypeList = ({ actions, monthlyParticipantsByCour
             <SelectsWrapper>
               <Select
                   name="month"
-                  onChange={onChangeMonth}
+                  onChange={onChangeSelect}
                   options={MONTHS_OPTIONS}
                   placeholder={MONTHS_OPTIONS[today.month - 1].label} />
               <Select
                   name="year"
-                  onChange={onChangeYear}
+                  onChange={onChangeSelect}
                   options={YEARS_OPTIONS}
                   placeholder={today.year} />
             </SelectsWrapper>

--- a/src/containers/stats/courttype/MonthlyParticipantsByCourtType.js
+++ b/src/containers/stats/courttype/MonthlyParticipantsByCourtType.js
@@ -1,8 +1,6 @@
 // @flow
 import React, { useState } from 'react';
 
-import { faSearch } from '@fortawesome/pro-duotone-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { List, Map } from 'immutable';
 import {
   Button,
@@ -10,7 +8,6 @@ import {
   CardSegment,
   ExpansionPanel,
   ExpansionPanelDetails,
-  IconButton,
   Select,
   Spinner,
   Typography,
@@ -66,8 +63,20 @@ const MonthlyParticipantsByCourtTypeList = ({ actions, monthlyParticipantsByCour
   const currentYearOption :Object = YEARS_OPTIONS.find((obj) => obj.value === today.year);
   const [year, setYear] = useState(currentYearOption);
 
-  const getNewData = () => {
-    actions.getMonthlyParticipantsByCourtType({ month: month.value, year: year.value });
+  const onChangeMonth = (newMonth :Object) => {
+    setMonth(newMonth);
+    actions.getMonthlyParticipantsByCourtType({
+      month: newMonth.value,
+      year: year.value,
+    });
+  };
+
+  const onChangeYear = (newYear :Object) => {
+    setYear(newYear);
+    actions.getMonthlyParticipantsByCourtType({
+      month: month.value,
+      year: newYear.value,
+    });
   };
 
   const downloadParticipantsByCourtType = () => {
@@ -96,18 +105,15 @@ const MonthlyParticipantsByCourtTypeList = ({ actions, monthlyParticipantsByCour
             <SelectsWrapper>
               <Select
                   name="month"
-                  onChange={setMonth}
+                  onChange={onChangeMonth}
                   options={MONTHS_OPTIONS}
                   placeholder={MONTHS_OPTIONS[today.month - 1].label} />
               <Select
                   name="year"
-                  onChange={setYear}
+                  onChange={onChangeYear}
                   options={YEARS_OPTIONS}
                   placeholder={today.year} />
             </SelectsWrapper>
-            <IconButton onClick={getNewData}>
-              <FontAwesomeIcon icon={faSearch} />
-            </IconButton>
           </ActionsWrapper>
         </GraphHeader>
       </Card>

--- a/src/containers/stats/courttype/ParticipantsByCourtType.js
+++ b/src/containers/stats/courttype/ParticipantsByCourtType.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { List, Map } from 'immutable';
 import {
@@ -35,7 +35,6 @@ import { requestIsPending } from '../../../utils/RequestStateUtils';
 import { SHARED, STATE, STATS } from '../../../utils/constants/ReduxStateConsts';
 import { getStatsData } from '../StatsActions';
 import {
-  ALL_TIME,
   MONTHLY,
   MONTHS_OPTIONS,
   TIME_FRAME_OPTIONS,
@@ -103,23 +102,15 @@ const ParticipantsByCourtTypeGraph = ({
     ...toolTipStyle
   };
 
-  const onTimeFrameSelectChange = (option :Object) => {
-    if (option.value === ALL_TIME) {
-      actions.getTotalParticipantsByCourtType({ month: month.value, year: year.value, timeFrame: ALL_TIME });
-      setTimeFrame(option);
-    }
-    else setTimeFrame(option);
+  const onChangeSelect = (selectedTimeValue :Object, event :Object) => {
+    if (event.name === 'month') setMonth(selectedTimeValue);
+    if (event.name === 'year') setYear(selectedTimeValue);
+    if (event.name === 'timeframe') setTimeFrame(selectedTimeValue);
   };
 
-  const onChangeMonth = (newMonth :Object) => {
-    setMonth(newMonth);
-    actions.getTotalParticipantsByCourtType({ month: newMonth.value, year: year.value, timeFrame: timeFrame.value });
-  };
-
-  const onChangeYear = (newYear :Object) => {
-    setYear(newYear);
-    actions.getTotalParticipantsByCourtType({ month: month.value, year: newYear.value, timeFrame: timeFrame.value });
-  };
+  useEffect(() => {
+    actions.getTotalParticipantsByCourtType({ month: month.value, year: year.value, timeFrame: timeFrame.value });
+  }, [actions, month, year, timeFrame]);
 
   return (
     <Card>
@@ -129,7 +120,8 @@ const ParticipantsByCourtTypeGraph = ({
           <HeaderActionsWrapper>
             <SmallSelectWrapper>
               <Select
-                  onChange={onTimeFrameSelectChange}
+                  name="timeframe"
+                  onChange={onChangeSelect}
                   options={TIME_FRAME_OPTIONS}
                   placeholder={TIME_FRAME_OPTIONS[2].label} />
             </SmallSelectWrapper>
@@ -148,12 +140,12 @@ const ParticipantsByCourtTypeGraph = ({
                   <Select
                       isDisabled={timeFrame.value === YEARLY}
                       name="month"
-                      onChange={onChangeMonth}
+                      onChange={onChangeSelect}
                       options={MONTHS_OPTIONS}
                       placeholder={MONTHS_OPTIONS[today.month - 1].label} />
                   <Select
                       name="year"
-                      onChange={onChangeYear}
+                      onChange={onChangeSelect}
                       options={YEARS_OPTIONS}
                       placeholder={today.year} />
                 </SelectsWrapper>

--- a/src/containers/stats/courttype/ParticipantsByCourtType.js
+++ b/src/containers/stats/courttype/ParticipantsByCourtType.js
@@ -1,15 +1,12 @@
 // @flow
 import React, { useState } from 'react';
 
-import { faSearch } from '@fortawesome/pro-duotone-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { List, Map } from 'immutable';
 import {
   Button,
   Card,
   CardSegment,
   Colors,
-  IconButton,
   Select,
   Spinner,
 } from 'lattice-ui-kit';
@@ -114,8 +111,14 @@ const ParticipantsByCourtTypeGraph = ({
     else setTimeFrame(option);
   };
 
-  const getNewParticipantsData = () => {
-    actions.getTotalParticipantsByCourtType({ month: month.value, year: year.value, timeFrame: timeFrame.value });
+  const onChangeMonth = (newMonth :Object) => {
+    setMonth(newMonth);
+    actions.getTotalParticipantsByCourtType({ month: newMonth.value, year: year.value, timeFrame: timeFrame.value });
+  };
+
+  const onChangeYear = (newYear :Object) => {
+    setYear(newYear);
+    actions.getTotalParticipantsByCourtType({ month: month.value, year: newYear.value, timeFrame: timeFrame.value });
   };
 
   return (
@@ -145,18 +148,15 @@ const ParticipantsByCourtTypeGraph = ({
                   <Select
                       isDisabled={timeFrame.value === YEARLY}
                       name="month"
-                      onChange={setMonth}
+                      onChange={onChangeMonth}
                       options={MONTHS_OPTIONS}
                       placeholder={MONTHS_OPTIONS[today.month - 1].label} />
                   <Select
                       name="year"
-                      onChange={setYear}
+                      onChange={onChangeYear}
                       options={YEARS_OPTIONS}
                       placeholder={today.year} />
                 </SelectsWrapper>
-                <IconButton onClick={getNewParticipantsData}>
-                  <FontAwesomeIcon icon={faSearch} />
-                </IconButton>
               </ActionsWrapper>
             </InnerHeaderRow>
           )

--- a/src/containers/stats/demographics/DemographicsGraphs.js
+++ b/src/containers/stats/demographics/DemographicsGraphs.js
@@ -9,6 +9,7 @@ import {
   CardSegment,
   CardStack,
   Select,
+  Typography,
 } from 'lattice-ui-kit';
 import { DateTime } from 'luxon';
 import { connect } from 'react-redux';
@@ -110,6 +111,7 @@ const DemographicsGraphs = ({
   return (
     <>
       <CardSegment padding="0 0 30px 0">
+        <Typography gutterBottom>Select the timeframe for viewing participant demographics:</Typography>
         <InnerHeaderRow>
           <HeaderActionsWrapper>
             <SmallSelectWrapper>

--- a/src/containers/stats/demographics/DemographicsGraphs.js
+++ b/src/containers/stats/demographics/DemographicsGraphs.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 import { Map } from 'immutable';
@@ -95,15 +95,14 @@ const DemographicsGraphs = ({
     else setTimeFrame(option);
   };
 
-  const onChangeMonth = (newMonth :Object) => {
-    setMonth(newMonth);
-    actions.getMonthlyDemographics({ month: newMonth.value, year: year.value });
+  const onChangeSelect = (selectedTimeValue :Object, event :Object) => {
+    if (event.name === 'month') setMonth(selectedTimeValue);
+    if (event.name === 'year') setYear(selectedTimeValue);
   };
 
-  const onChangeYear = (newYear :Object) => {
-    setYear(newYear);
-    actions.getMonthlyDemographics({ month: month.value, year: newYear.value });
-  };
+  useEffect(() => {
+    actions.getMonthlyDemographics({ month: month.value, year: year.value });
+  }, [actions, month, year]);
 
   const isFetchingDemographics = requestIsPending(requestStates[GET_MONTHLY_DEMOGRAPHICS])
     || requestIsPending(requestStates[GET_PARTICIPANTS_DEMOGRAPHICS]);
@@ -129,12 +128,12 @@ const DemographicsGraphs = ({
                 <SelectsWrapper>
                   <Select
                       name="month"
-                      onChange={onChangeMonth}
+                      onChange={onChangeSelect}
                       options={MONTHS_OPTIONS}
                       placeholder={MONTHS_OPTIONS[today.month - 1].label} />
                   <Select
                       name="year"
-                      onChange={onChangeYear}
+                      onChange={onChangeSelect}
                       options={YEARS_OPTIONS}
                       placeholder={today.year} />
                 </SelectsWrapper>

--- a/src/containers/stats/demographics/DemographicsGraphs.js
+++ b/src/containers/stats/demographics/DemographicsGraphs.js
@@ -12,7 +12,6 @@ import {
   CardStack,
   IconButton,
   Select,
-  Spinner,
 } from 'lattice-ui-kit';
 import { DateTime } from 'luxon';
 import { connect } from 'react-redux';
@@ -102,6 +101,9 @@ const DemographicsGraphs = ({
     actions.getMonthlyDemographics({ month: month.value, year: year.value });
   };
 
+  const isFetchingDemographics = requestIsPending(requestStates[GET_MONTHLY_DEMOGRAPHICS])
+    || requestIsPending(requestStates[GET_PARTICIPANTS_DEMOGRAPHICS]);
+
   return (
     <>
       <CardSegment padding="0 0 30px 0">
@@ -139,49 +141,43 @@ const DemographicsGraphs = ({
           )
         }
       </CardSegment>
-      {
-        requestIsPending(requestStates[GET_MONTHLY_DEMOGRAPHICS])
-            || requestIsPending(requestStates[GET_PARTICIPANTS_DEMOGRAPHICS])
-          ? (
-            <Spinner size="2x" />
-          ) : (
-            <CardStack>
-              <Card>
-                <DemographicsCardHeader>
-                  <div>Race</div>
-                  <Button
-                      isLoading={requestIsPending(requestStates[DOWNLOAD_DEMOGRAPHICS_DATA])}
-                      onClick={() => actions.downloadDemographicsData(formatRadialChartData(raceDemographics))}>
-                    Download
-                  </Button>
-                </DemographicsCardHeader>
-                <RaceChart raceDemographics={raceDemographics} />
-              </Card>
-              <Card>
-                <DemographicsCardHeader>
-                  <div>Ethnicity</div>
-                  <Button
-                      isLoading={requestIsPending(requestStates[DOWNLOAD_DEMOGRAPHICS_DATA])}
-                      onClick={() => actions.downloadDemographicsData(formatRadialChartData(ethnicityDemographics))}>
-                    Download
-                  </Button>
-                </DemographicsCardHeader>
-                <EthnicityChart ethnicityDemographics={ethnicityDemographics} />
-              </Card>
-              <Card>
-                <DemographicsCardHeader>
-                  <div>Sex</div>
-                  <Button
-                      isLoading={requestIsPending(requestStates[DOWNLOAD_DEMOGRAPHICS_DATA])}
-                      onClick={() => actions.downloadDemographicsData(formatRadialChartData(sexDemographics))}>
-                    Download
-                  </Button>
-                </DemographicsCardHeader>
-                <SexChart sexDemographics={sexDemographics} />
-              </Card>
-            </CardStack>
-          )
-      }
+      <CardStack>
+        <Card>
+          <DemographicsCardHeader>
+            <div>Race</div>
+            <Button
+                isLoading={requestIsPending(requestStates[DOWNLOAD_DEMOGRAPHICS_DATA])}
+                onClick={() => actions.downloadDemographicsData(formatRadialChartData(raceDemographics))}>
+              Download
+            </Button>
+          </DemographicsCardHeader>
+          <RaceChart isFetchingDemographics={isFetchingDemographics} raceDemographics={raceDemographics} />
+        </Card>
+        <Card>
+          <DemographicsCardHeader>
+            <div>Ethnicity</div>
+            <Button
+                isLoading={requestIsPending(requestStates[DOWNLOAD_DEMOGRAPHICS_DATA])}
+                onClick={() => actions.downloadDemographicsData(formatRadialChartData(ethnicityDemographics))}>
+              Download
+            </Button>
+          </DemographicsCardHeader>
+          <EthnicityChart
+              ethnicityDemographics={ethnicityDemographics}
+              isFetchingDemographics={isFetchingDemographics} />
+        </Card>
+        <Card>
+          <DemographicsCardHeader>
+            <div>Sex</div>
+            <Button
+                isLoading={requestIsPending(requestStates[DOWNLOAD_DEMOGRAPHICS_DATA])}
+                onClick={() => actions.downloadDemographicsData(formatRadialChartData(sexDemographics))}>
+              Download
+            </Button>
+          </DemographicsCardHeader>
+          <SexChart isFetchingDemographics={isFetchingDemographics} sexDemographics={sexDemographics} />
+        </Card>
+      </CardStack>
     </>
   );
 };

--- a/src/containers/stats/demographics/DemographicsGraphs.js
+++ b/src/containers/stats/demographics/DemographicsGraphs.js
@@ -2,15 +2,12 @@
 import React, { useState } from 'react';
 
 import styled from 'styled-components';
-import { faSearch } from '@fortawesome/pro-duotone-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Map } from 'immutable';
 import {
   Button,
   Card,
   CardSegment,
   CardStack,
-  IconButton,
   Select,
 } from 'lattice-ui-kit';
 import { DateTime } from 'luxon';
@@ -97,8 +94,14 @@ const DemographicsGraphs = ({
     else setTimeFrame(option);
   };
 
-  const getMonthlyDemographicsData = () => {
-    actions.getMonthlyDemographics({ month: month.value, year: year.value });
+  const onChangeMonth = (newMonth :Object) => {
+    setMonth(newMonth);
+    actions.getMonthlyDemographics({ month: newMonth.value, year: year.value });
+  };
+
+  const onChangeYear = (newYear :Object) => {
+    setYear(newYear);
+    actions.getMonthlyDemographics({ month: month.value, year: newYear.value });
   };
 
   const isFetchingDemographics = requestIsPending(requestStates[GET_MONTHLY_DEMOGRAPHICS])
@@ -124,18 +127,15 @@ const DemographicsGraphs = ({
                 <SelectsWrapper>
                   <Select
                       name="month"
-                      onChange={setMonth}
+                      onChange={onChangeMonth}
                       options={MONTHS_OPTIONS}
                       placeholder={MONTHS_OPTIONS[today.month - 1].label} />
                   <Select
                       name="year"
-                      onChange={setYear}
+                      onChange={onChangeYear}
                       options={YEARS_OPTIONS}
                       placeholder={today.year} />
                 </SelectsWrapper>
-                <IconButton onClick={getMonthlyDemographicsData}>
-                  <FontAwesomeIcon icon={faSearch} />
-                </IconButton>
               </ActionsWrapper>
             </InnerHeaderRow>
           )

--- a/src/containers/stats/demographics/EthnicityChart.js
+++ b/src/containers/stats/demographics/EthnicityChart.js
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 
 import { List, Map } from 'immutable';
-import { CardSegment, Colors } from 'lattice-ui-kit';
+import { CardSegment, Colors, Spinner } from 'lattice-ui-kit';
 import { Hint, RadialChart } from 'react-vis';
 
 import { toolTipStyle } from '../styled/GraphStyles';
@@ -19,9 +19,10 @@ const { NEUTRAL } = Colors;
 
 type Props = {
   ethnicityDemographics :Map;
+  isFetchingDemographics :boolean;
 };
 
-const EthnicityChart = ({ ethnicityDemographics } :Props) => {
+const EthnicityChart = ({ ethnicityDemographics, isFetchingDemographics } :Props) => {
 
   const [hintValue, setHintValue] = useState();
   const toolTipStyleWithBackground :Object = {
@@ -32,42 +33,54 @@ const EthnicityChart = ({ ethnicityDemographics } :Props) => {
   const { chartData, valuesNotFound } :Object = formatRadialChartData(ethnicityDemographics);
   const sortedListOfEths :List = getListForRadialChartKey(chartData, valuesNotFound);
   return (
-    <CardSegment>
-      <CardSegment padding="0 0 10px 0" vertical={false}>
-        <RadialChart
-            colorType="literal"
-            data={chartData}
-            height={400}
-            onValueMouseOver={(v) => setHintValue(v)}
-            onValueMouseOut={() => setHintValue(undefined)}
-            width={400}>
-          {
-            hintValue && (
-              <Hint
-                  align={{ vertical: 'top', horizontal: 'right' }}
-                  format={() => [
-                    { title: hintValue.name, value: '' },
-                    { title: 'percentage', value: hintValue.label },
-                    { title: 'count', value: `${hintValue.count}` }
-                  ]}
-                  style={toolTipStyleWithBackground}
-                  value={hintValue} />
-            )
-          }
-        </RadialChart>
-        <KeyWrapper padding="0">
-          {
-            sortedListOfEths.map(({ color, name } :Object) => (
-              <KeyItemWrapper key={name}>
-                <KeySquare color={color} />
-                <KeyItem>{ name }</KeyItem>
-              </KeyItemWrapper>
-            ))
-          }
-        </KeyWrapper>
-      </CardSegment>
-      <GraphDescription>Hover over the chart to see more details.</GraphDescription>
-    </CardSegment>
+    <>
+      {
+        isFetchingDemographics
+          ? (
+            <CardSegment>
+              <Spinner size="2x" />
+            </CardSegment>
+          )
+          : (
+            <CardSegment>
+              <CardSegment padding="0 0 10px 0" vertical={false}>
+                <RadialChart
+                    colorType="literal"
+                    data={chartData}
+                    height={400}
+                    onValueMouseOver={(v) => setHintValue(v)}
+                    onValueMouseOut={() => setHintValue(undefined)}
+                    width={400}>
+                  {
+                    hintValue && (
+                      <Hint
+                          align={{ vertical: 'top', horizontal: 'right' }}
+                          format={() => [
+                            { title: hintValue.name, value: '' },
+                            { title: 'percentage', value: hintValue.label },
+                            { title: 'count', value: `${hintValue.count}` }
+                          ]}
+                          style={toolTipStyleWithBackground}
+                          value={hintValue} />
+                    )
+                  }
+                </RadialChart>
+                <KeyWrapper padding="0">
+                  {
+                    sortedListOfEths.map(({ color, name } :Object) => (
+                      <KeyItemWrapper key={name}>
+                        <KeySquare color={color} />
+                        <KeyItem>{ name }</KeyItem>
+                      </KeyItemWrapper>
+                    ))
+                  }
+                </KeyWrapper>
+              </CardSegment>
+              <GraphDescription>Hover over the chart to see more details.</GraphDescription>
+            </CardSegment>
+          )
+      }
+    </>
   );
 };
 

--- a/src/containers/stats/demographics/RaceChart.js
+++ b/src/containers/stats/demographics/RaceChart.js
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 
 import { List, Map } from 'immutable';
-import { CardSegment, Colors } from 'lattice-ui-kit';
+import { CardSegment, Colors, Spinner } from 'lattice-ui-kit';
 import { Hint, RadialChart } from 'react-vis';
 
 import { toolTipStyle } from '../styled/GraphStyles';
@@ -18,10 +18,11 @@ import { formatRadialChartData, getListForRadialChartKey } from '../utils/StatsU
 const { NEUTRAL } = Colors;
 
 type Props = {
+  isFetchingDemographics :boolean;
   raceDemographics :Map;
 };
 
-const RaceChart = ({ raceDemographics } :Props) => {
+const RaceChart = ({ isFetchingDemographics, raceDemographics } :Props) => {
 
   const [hintValue, setHintValue] = useState();
   const toolTipStyleWithBackground :Object = {
@@ -32,42 +33,54 @@ const RaceChart = ({ raceDemographics } :Props) => {
   const { chartData, valuesNotFound } :Object = formatRadialChartData(raceDemographics);
   const sortedListOfRaces :List = getListForRadialChartKey(chartData, valuesNotFound);
   return (
-    <CardSegment>
-      <CardSegment padding="0 0 10px 0" vertical={false}>
-        <RadialChart
-            colorType="literal"
-            data={chartData}
-            height={400}
-            onValueMouseOver={(v) => setHintValue(v)}
-            onValueMouseOut={() => setHintValue(undefined)}
-            width={400}>
-          {
-            hintValue && (
-              <Hint
-                  align={{ vertical: 'top', horizontal: 'right' }}
-                  format={() => [
-                    { title: hintValue.name, value: '' },
-                    { title: 'percentage', value: hintValue.label },
-                    { title: 'count', value: `${hintValue.count}` }
-                  ]}
-                  style={toolTipStyleWithBackground}
-                  value={hintValue} />
-            )
-          }
-        </RadialChart>
-        <KeyWrapper padding="0">
-          {
-            sortedListOfRaces.map(({ color, name } :Object) => (
-              <KeyItemWrapper key={name}>
-                <KeySquare color={color} />
-                <KeyItem>{ name }</KeyItem>
-              </KeyItemWrapper>
-            ))
-          }
-        </KeyWrapper>
-      </CardSegment>
-      <GraphDescription>Hover over the chart to see more details.</GraphDescription>
-    </CardSegment>
+    <>
+      {
+        isFetchingDemographics
+          ? (
+            <CardSegment>
+              <Spinner size="2x" />
+            </CardSegment>
+          )
+          : (
+            <CardSegment>
+              <CardSegment padding="0 0 10px 0" vertical={false}>
+                <RadialChart
+                    colorType="literal"
+                    data={chartData}
+                    height={400}
+                    onValueMouseOver={(v) => setHintValue(v)}
+                    onValueMouseOut={() => setHintValue(undefined)}
+                    width={400}>
+                  {
+                    hintValue && (
+                      <Hint
+                          align={{ vertical: 'top', horizontal: 'right' }}
+                          format={() => [
+                            { title: hintValue.name, value: '' },
+                            { title: 'percentage', value: hintValue.label },
+                            { title: 'count', value: `${hintValue.count}` }
+                          ]}
+                          style={toolTipStyleWithBackground}
+                          value={hintValue} />
+                    )
+                  }
+                </RadialChart>
+                <KeyWrapper padding="0">
+                  {
+                    sortedListOfRaces.map(({ color, name } :Object) => (
+                      <KeyItemWrapper key={name}>
+                        <KeySquare color={color} />
+                        <KeyItem>{ name }</KeyItem>
+                      </KeyItemWrapper>
+                    ))
+                  }
+                </KeyWrapper>
+              </CardSegment>
+              <GraphDescription>Hover over the chart to see more details.</GraphDescription>
+            </CardSegment>
+          )
+      }
+    </>
   );
 };
 

--- a/src/containers/stats/demographics/SexChart.js
+++ b/src/containers/stats/demographics/SexChart.js
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 
 import { List, Map } from 'immutable';
-import { CardSegment, Colors } from 'lattice-ui-kit';
+import { CardSegment, Colors, Spinner } from 'lattice-ui-kit';
 import { Hint, RadialChart } from 'react-vis';
 
 import { toolTipStyle } from '../styled/GraphStyles';
@@ -18,10 +18,11 @@ import { formatRadialChartData, getListForRadialChartKey } from '../utils/StatsU
 const { NEUTRAL } = Colors;
 
 type Props = {
+  isFetchingDemographics :boolean;
   sexDemographics :Map;
 };
 
-const SexChart = ({ sexDemographics } :Props) => {
+const SexChart = ({ isFetchingDemographics, sexDemographics } :Props) => {
 
   const [hintValue, setHintValue] = useState();
   const toolTipStyleWithBackground :Object = {
@@ -32,42 +33,54 @@ const SexChart = ({ sexDemographics } :Props) => {
   const { chartData, valuesNotFound } :Object = formatRadialChartData(sexDemographics);
   const sortedListOfSexes :List = getListForRadialChartKey(chartData, valuesNotFound);
   return (
-    <CardSegment>
-      <CardSegment padding="0 0 10px 0" vertical={false}>
-        <RadialChart
-            colorType="literal"
-            data={chartData}
-            height={400}
-            onValueMouseOver={(v) => setHintValue(v)}
-            onValueMouseOut={() => setHintValue(undefined)}
-            width={400}>
-          {
-            hintValue && (
-              <Hint
-                  align={{ vertical: 'top', horizontal: 'right' }}
-                  format={() => [
-                    { title: hintValue.name, value: '' },
-                    { title: 'percentage', value: hintValue.label },
-                    { title: 'count', value: `${hintValue.count}` }
-                  ]}
-                  style={toolTipStyleWithBackground}
-                  value={hintValue} />
-            )
-          }
-        </RadialChart>
-        <KeyWrapper padding="0" vertical>
-          {
-            sortedListOfSexes.map(({ color, name } :Object) => (
-              <KeyItemWrapper key={name}>
-                <KeySquare color={color} />
-                <KeyItem>{ name }</KeyItem>
-              </KeyItemWrapper>
-            ))
-          }
-        </KeyWrapper>
-      </CardSegment>
-      <GraphDescription>Hover over the chart to see more details.</GraphDescription>
-    </CardSegment>
+    <>
+      {
+        isFetchingDemographics
+          ? (
+            <CardSegment>
+              <Spinner size="2x" />
+            </CardSegment>
+          )
+          : (
+            <CardSegment>
+              <CardSegment padding="0 0 10px 0" vertical={false}>
+                <RadialChart
+                    colorType="literal"
+                    data={chartData}
+                    height={400}
+                    onValueMouseOver={(v) => setHintValue(v)}
+                    onValueMouseOut={() => setHintValue(undefined)}
+                    width={400}>
+                  {
+                    hintValue && (
+                      <Hint
+                          align={{ vertical: 'top', horizontal: 'right' }}
+                          format={() => [
+                            { title: hintValue.name, value: '' },
+                            { title: 'percentage', value: hintValue.label },
+                            { title: 'count', value: `${hintValue.count}` }
+                          ]}
+                          style={toolTipStyleWithBackground}
+                          value={hintValue} />
+                    )
+                  }
+                </RadialChart>
+                <KeyWrapper padding="0" vertical>
+                  {
+                    sortedListOfSexes.map(({ color, name } :Object) => (
+                      <KeyItemWrapper key={name}>
+                        <KeySquare color={color} />
+                        <KeyItem>{ name }</KeyItem>
+                      </KeyItemWrapper>
+                    ))
+                  }
+                </KeyWrapper>
+              </CardSegment>
+              <GraphDescription>Hover over the chart to see more details.</GraphDescription>
+            </CardSegment>
+          )
+      }
+    </>
   );
 };
 

--- a/src/containers/stats/worksite/WorksiteGraphs.js
+++ b/src/containers/stats/worksite/WorksiteGraphs.js
@@ -1,8 +1,6 @@
 // @flow
 import React, { useState } from 'react';
 
-import { faSearch } from '@fortawesome/pro-duotone-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { List, Map } from 'immutable';
 import {
   Button,
@@ -11,7 +9,6 @@ import {
   CardStack,
   ExpansionPanel,
   ExpansionPanelDetails,
-  IconButton,
   Select,
   Spinner,
 } from 'lattice-ui-kit';
@@ -91,12 +88,24 @@ const WorksiteGraphs = ({
   const [participantsMonth, setParticipantsMonth] = useState(MONTHS_OPTIONS[today.month - 1]);
   const [participantsYear, setParticipantsYear] = useState(currentYearOption);
 
-  const getHoursData = () => {
-    actions.getHoursWorkedByWorksite({ month: hoursMonth.value, year: hoursYear.value, timeFrame: timeFrame.value });
+  const onChangeHoursMonth = (newMonth :Object) => {
+    setHoursMonth(newMonth);
+    actions.getHoursWorkedByWorksite({ month: newMonth.value, year: hoursYear.value, timeFrame: timeFrame.value });
   };
 
-  const getParticipantsData = () => {
-    actions.getMonthlyParticipantsByWorksite({ month: participantsMonth.value, year: participantsYear.value });
+  const onChangeHoursYear = (newYear :Object) => {
+    setHoursYear(newYear);
+    actions.getHoursWorkedByWorksite({ month: hoursMonth.value, year: newYear.value, timeFrame: timeFrame.value });
+  };
+
+  const onChangeParticipantsMonth = (newMonth :Object) => {
+    setParticipantsMonth(newMonth);
+    actions.getMonthlyParticipantsByWorksite({ month: newMonth.value, year: participantsYear.value });
+  };
+
+  const onChangeParticipantsYear = (newYear :Object) => {
+    setParticipantsYear(newYear);
+    actions.getMonthlyParticipantsByWorksite({ month: participantsMonth.value, year: newYear.value });
   };
 
   const onTimeFrameSelectChange = (option :Object) => {
@@ -160,18 +169,15 @@ const WorksiteGraphs = ({
                     <Select
                         isDisabled={timeFrame.value === YEARLY}
                         name="month"
-                        onChange={setHoursMonth}
+                        onChange={onChangeHoursMonth}
                         options={MONTHS_OPTIONS}
                         placeholder={MONTHS_OPTIONS[today.month - 1].label} />
                     <Select
                         name="year"
-                        onChange={setHoursYear}
+                        onChange={onChangeHoursYear}
                         options={YEARS_OPTIONS}
                         placeholder={today.year} />
                   </SelectsWrapper>
-                  <IconButton onClick={getHoursData}>
-                    <FontAwesomeIcon icon={faSearch} />
-                  </IconButton>
                 </ActionsWrapper>
               </InnerHeaderRow>
             )
@@ -203,18 +209,15 @@ const WorksiteGraphs = ({
             <SelectsWrapper>
               <Select
                   name="month"
-                  onChange={setParticipantsMonth}
+                  onChange={onChangeParticipantsMonth}
                   options={MONTHS_OPTIONS}
                   placeholder={MONTHS_OPTIONS[today.month - 1].label} />
               <Select
                   name="year"
-                  onChange={setParticipantsYear}
+                  onChange={onChangeParticipantsYear}
                   options={YEARS_OPTIONS}
                   placeholder={today.year} />
             </SelectsWrapper>
-            <IconButton onClick={getParticipantsData}>
-              <FontAwesomeIcon icon={faSearch} />
-            </IconButton>
           </ActionsWrapper>
         </GraphHeader>
       </Card>

--- a/src/containers/stats/worksite/WorksiteGraphs.js
+++ b/src/containers/stats/worksite/WorksiteGraphs.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { List, Map } from 'immutable';
 import {
@@ -30,7 +30,6 @@ import {
 import { requestIsPending } from '../../../utils/RequestStateUtils';
 import { SHARED, STATE, STATS } from '../../../utils/constants/ReduxStateConsts';
 import {
-  ALL_TIME,
   MONTHLY,
   MONTHS_OPTIONS,
   TIME_FRAME_OPTIONS,
@@ -88,33 +87,24 @@ const WorksiteGraphs = ({
   const [participantsMonth, setParticipantsMonth] = useState(MONTHS_OPTIONS[today.month - 1]);
   const [participantsYear, setParticipantsYear] = useState(currentYearOption);
 
-  const onChangeHoursMonth = (newMonth :Object) => {
-    setHoursMonth(newMonth);
-    actions.getHoursWorkedByWorksite({ month: newMonth.value, year: hoursYear.value, timeFrame: timeFrame.value });
+  const onChangeHoursSelect = (selectedTimeValue :Object, event :Object) => {
+    if (event.name === 'month') setHoursMonth(selectedTimeValue);
+    if (event.name === 'year') setHoursYear(selectedTimeValue);
+    if (event.name === 'timeframe') setTimeFrame(selectedTimeValue);
   };
 
-  const onChangeHoursYear = (newYear :Object) => {
-    setHoursYear(newYear);
-    actions.getHoursWorkedByWorksite({ month: hoursMonth.value, year: newYear.value, timeFrame: timeFrame.value });
+  useEffect(() => {
+    actions.getHoursWorkedByWorksite({ month: hoursMonth.value, year: hoursYear.value, timeFrame: timeFrame.value });
+  }, [actions, hoursMonth, hoursYear, timeFrame]);
+
+  const onChangeParticipantsSelect = (selectedTimeValue :Object, event :Object) => {
+    if (event.name === 'month') setParticipantsMonth(selectedTimeValue);
+    if (event.name === 'year') setParticipantsYear(selectedTimeValue);
   };
 
-  const onChangeParticipantsMonth = (newMonth :Object) => {
-    setParticipantsMonth(newMonth);
-    actions.getMonthlyParticipantsByWorksite({ month: newMonth.value, year: participantsYear.value });
-  };
-
-  const onChangeParticipantsYear = (newYear :Object) => {
-    setParticipantsYear(newYear);
-    actions.getMonthlyParticipantsByWorksite({ month: participantsMonth.value, year: newYear.value });
-  };
-
-  const onTimeFrameSelectChange = (option :Object) => {
-    if (option.value === ALL_TIME) {
-      actions.getHoursWorkedByWorksite();
-      setTimeFrame(option);
-    }
-    else setTimeFrame(option);
-  };
+  useEffect(() => {
+    actions.getMonthlyParticipantsByWorksite({ month: participantsMonth.value, year: participantsYear.value });
+  }, [actions, participantsMonth, participantsYear]);
 
   const worksites :List = participantsByWorksite.keySeq().toList().sort();
 
@@ -150,7 +140,8 @@ const WorksiteGraphs = ({
             <HeaderActionsWrapper>
               <SmallSelectWrapper>
                 <Select
-                    onChange={onTimeFrameSelectChange}
+                    name="timeframe"
+                    onChange={onChangeHoursSelect}
                     options={TIME_FRAME_OPTIONS}
                     placeholder={TIME_FRAME_OPTIONS[2].label} />
               </SmallSelectWrapper>
@@ -169,12 +160,12 @@ const WorksiteGraphs = ({
                     <Select
                         isDisabled={timeFrame.value === YEARLY}
                         name="month"
-                        onChange={onChangeHoursMonth}
+                        onChange={onChangeHoursSelect}
                         options={MONTHS_OPTIONS}
                         placeholder={MONTHS_OPTIONS[today.month - 1].label} />
                     <Select
                         name="year"
-                        onChange={onChangeHoursYear}
+                        onChange={onChangeHoursSelect}
                         options={YEARS_OPTIONS}
                         placeholder={today.year} />
                   </SelectsWrapper>
@@ -209,12 +200,12 @@ const WorksiteGraphs = ({
             <SelectsWrapper>
               <Select
                   name="month"
-                  onChange={onChangeParticipantsMonth}
+                  onChange={onChangeParticipantsSelect}
                   options={MONTHS_OPTIONS}
                   placeholder={MONTHS_OPTIONS[today.month - 1].label} />
               <Select
                   name="year"
-                  onChange={onChangeParticipantsYear}
+                  onChange={onChangeParticipantsSelect}
                   options={YEARS_OPTIONS}
                   placeholder={today.year} />
             </SelectsWrapper>


### PR DESCRIPTION
MAKES STYLE UPDATES:

updated the month/year selects to search on change of either, instead of using a search button to do so:

https://user-images.githubusercontent.com/32921059/130126774-5c262d64-656a-4707-b96c-bcaa05337992.mov





updated demographics tab to render a spinner in each chart rather than replacing the entire page with a single spinner (causing the whole page to jump up):

https://user-images.githubusercontent.com/32921059/126180746-fa9c2298-f177-4613-a8dd-70767bc0edce.mov

fixed a few other style issues



FIXES BUGS:

- Total Enrollments By Court Type: was showing all enrollment statuses ever which doesn't make sense. Now it shows 1 enrollment status per enrollment (the most recent one or the one that indicates completion). So now the total enrollments in that graph = the actual total enrollments.
- Total Participants by Court Type: monthly/year graph stats didn't display at all because there was a bug in the saga.